### PR TITLE
Create setter function

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -8,6 +8,8 @@
    compilation buffer.
  * added eclim-java-generate-getter which generates a getter method
  for the symbol at point.
+ * added eclim-java-generate-setter which generates a setter method
+ for the symbol at point.
  * added eclim-java-refactor-move-class which allows moving a top level
    class or interface from one package to another.
  * added eclim-project-setting-set which can assign an Eclim project

--- a/eclim-java.el
+++ b/eclim-java.el
@@ -254,6 +254,14 @@ has been found."
                      (eclim--current-encoding)))
   (eclim--java-generate-bean-properties project file offset encoding "getter"))
 
+(defun eclim-java-generate-setter (project file offset encoding)
+  "Generates a setter method for the symbol at point."
+  (interactive (list (eclim-project-name)
+                     (eclim--project-current-file)
+                     (eclim--byte-offset)
+                     (eclim--current-encoding)))
+  (eclim--java-generate-bean-properties project file offset encoding "setter"))
+
 (defun eclim-java-constructor ()
   (interactive)
   (eclim/execute-command "java_constructor" "-p" "-f" "-o"))


### PR DESCRIPTION
Adds a setter function to eclim.

All three methods (`eclim-java-generate-setter`, `eclim-java-generate-getter` and `eclim-java-generate-getter-and-setter`) have basically the same code with the exception a unique string. I feel as if this should be condensed but it's not that many lines of code anyways.