### PR TITLE
Fix for eclim-run-java-doc.

### DIFF
--- a/eclim-java.el
+++ b/eclim-java.el
@@ -226,11 +226,11 @@ has been found."
 (defun eclim-run-java-doc ()
   "Run Javadoc on current or all projects."
   (interactive)
-  (let ((project-list (mapcar 'third (eclim/project-list))))
+  (let ((proj-list (eclim/project-list)))
     (if (y-or-n-p "Run Javadoc for all projects?")
-        (dolist (project project-list)
-          (eclim/execute-command "javadoc" ("-p" project)))
-      (eclim/execute-command "javadoc" "-p"))
+        (dotimes (i (length proj-list))
+            (eclim--call-process-no-parse "javadoc" "-p" (rest (assq 'name (elt proj-list i)))))
+      (eclim--call-process-no-parse "javadoc" "-p"))
     (message "Javadoc creation finished.")))
 
 (defun eclim-java-format ()

--- a/eclim.el
+++ b/eclim.el
@@ -177,13 +177,17 @@ where <encoding> is the corresponding java name for this encoding." e e)))
               (error (match-string 1 result)))
              (t (error result)))))))
 
+(defun eclim--call-process-no-parse (&rest args)
+  "Calls eclim with the supplied arguments but does not attempt to parse the result. "
+  (let ((cmd (eclim--make-command args)))
+    (when eclim-print-debug-messages (message "Executing: %s" cmd))
+    (shell-command-to-string cmd)))
+
 (defun eclim--call-process (&rest args)
   "Calls eclim with the supplied arguments. Consider using
 `eclim/execute-command' instead, as it has argument expansion,
 error checking, and some other niceties.."
-  (let ((cmd (eclim--make-command args)))
-    (when eclim-print-debug-messages (message "Executing: %s" cmd))
-    (eclim--parse-result (shell-command-to-string cmd))))
+  (eclim--parse-result (apply 'eclim--call-process-no-parse args)))
 
 (defvar eclim--currently-running-async-calls nil)
 


### PR DESCRIPTION
`eclim-run-java-doc` was failing for the following reasons:

1. The output from `eclim/project-list` was not being parsed correctly.

1. `eclim/execute-command` expects the Eclim server to return a valid JSON string.

1. The `javadoc` command for the Eclim server returns an unformatted string and not a JSON string.

To fix `eclim-run-java-doc`, a new function, `eclim--call-process-no-parse`, was added to call the Eclim server process and not parse the output it returns. 