### PR TITLE
Utilize the arhive_read command to open a file stored in a jar or zip

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -16,6 +16,7 @@
    setting.
  * Fixed some compiler warnings. Not all compiler warnings were fixed
    since those changes could not be tested.
+ * Utilize the arhive_read command to open a file stored in a jar or zip
 
 == 0.3
 

--- a/eclim.el
+++ b/eclim.el
@@ -372,7 +372,7 @@ FILENAME is given, return that file's  project name instead."
         (kill-buffer old-buffer)))))
 
 (defun eclim--find-display-results (pattern results &optional open-single-file)
-  (let ((results (cl-remove-if (lambda (result) (string-match (rx bol (or "jar" "zip") ":") (assoc-default 'filename result))) results)))
+  (let ((results results))
     (if (and (= 1 (length results)) open-single-file) (eclim--visit-declaration (elt results 0))
       (pop-to-buffer (get-buffer-create "*eclim: find"))
       (let ((buffer-read-only nil))
@@ -396,7 +396,14 @@ FILENAME is given, return that file's  project name instead."
             (assoc-default 'column line)
             (assoc-default 'message line))))
 
+(defun eclim--extract-archive-file (line)
+  (if (string-match (rx bol (or "jar" "zip") ":") (assoc-default 'filename line))
+      (eclim/with-results results ("archive_read" "-f" (assoc-default 'filename line))
+        (results))
+    line))
+
 (defun eclim--visit-declaration (line)
+  (let (line (eclim--extract-archive-file line)))
   (ring-insert find-tag-marker-ring (point-marker))
   (eclim--find-file (assoc-default 'filename line))
   (goto-char (point-min))


### PR DESCRIPTION
This issue was brought up in an issue in the other repo: https://github.com/senny/emacs-eclim/issues/250

Eclim has an "archive_read" command that accepts a path to a file within a jar or zip. The command writes the content of the file into a temporary file and opens it in a buffer. This allows the java "goto declaration" or "find type" commands to now be able to open references to compiled dependencies.

NOTE: This is the first few lines of clojure/elisp/lisp I have ever written. I got this to work for both jar and zip files within my distribution of spacemacs but have not tested it against anything else. So any pointers on how to make this better would be great. I wanted to only execute the archive_read command on files that were intended to be opened to prevent a bunch of useless files from being created.