### PR TITLE
Open files in archives. Fixes http://github.com/senny/emacs-eclim/iss…

### DIFF
--- a/eclim.el
+++ b/eclim.el
@@ -120,7 +120,8 @@ in the current workspace."
     ("utf-8-unix" . "utf-8")
     ("utf-8-emacs-unix" . "utf-8")))
 
-(defvar eclim--compressed-urls-regexp "^\\(\\(?:jar\\|file\\|zip\\)://\\)")
+(defvar eclim--compressed-urls-regexp
+  "^\\(\\(?:jar\\|file\\|zip\\):\\(?:file:\\)?//\\)")
 (defvar eclim--compressed-file-path-replacement-regexp "\\\\")
 (defvar eclim--compressed-file-path-removal-regexp "^/")
 
@@ -372,19 +373,19 @@ FILENAME is given, return that file's  project name instead."
         (kill-buffer old-buffer)))))
 
 (defun eclim--find-display-results (pattern results &optional open-single-file)
-  (let ((results (cl-remove-if (lambda (result) (string-match (rx bol (or "jar" "zip") ":") (assoc-default 'filename result))) results)))
-    (if (and (= 1 (length results)) open-single-file) (eclim--visit-declaration (elt results 0))
-      (pop-to-buffer (get-buffer-create "*eclim: find"))
-      (let ((buffer-read-only nil))
-        (erase-buffer)
-        (insert (concat "-*- mode: eclim-find; default-directory: " default-directory " -*-"))
-        (newline 2)
-        (insert (concat "eclim java_search -p " pattern))
-        (newline)
-        (loop for result across results
-              do (insert (eclim--format-find-result result default-directory)))
-        (goto-char 0)
-        (grep-mode)))))
+  (if (and (= 1 (length results)) open-single-file)
+      (eclim--visit-declaration (elt results 0))
+    (pop-to-buffer (get-buffer-create "*eclim: find"))
+    (let ((buffer-read-only nil))
+      (erase-buffer)
+      (insert (concat "-*- mode: eclim-find; default-directory: " default-directory " -*-"))
+      (newline 2)
+      (insert (concat "eclim java_search -p " pattern))
+      (newline)
+      (loop for result across results
+            do (insert (eclim--format-find-result result default-directory)))
+      (goto-char 0)
+      (grep-mode))))
 
 (defun eclim--format-find-result (line &optional directory)
   (let ((converted-directory (replace-regexp-in-string "\\\\" "/" (assoc-default 'filename line))))

--- a/eclim.el
+++ b/eclim.el
@@ -375,7 +375,7 @@ FILENAME is given, return that file's  project name instead."
 (defun eclim--find-display-results (pattern results &optional open-single-file)
   (if (and (= 1 (length results)) open-single-file)
       (eclim--visit-declaration (elt results 0))
-    (pop-to-buffer (get-buffer-create "*eclim: find"))
+    (pop-to-buffer (get-buffer-create "*eclim: find*"))
     (let ((buffer-read-only nil))
       (erase-buffer)
       (insert (concat "-*- mode: eclim-find; default-directory: " default-directory " -*-"))
@@ -388,15 +388,25 @@ FILENAME is given, return that file's  project name instead."
       (grep-mode))))
 
 (defun eclim--format-find-result (line &optional directory)
-  (let ((converted-directory (replace-regexp-in-string "\\\\" "/" (assoc-default 'filename line))))
-    (format "%s:%d:%d:%s\n"
-            (if converted-directory
-                (replace-regexp-in-string (concat (regexp-quote directory) "/?") "" converted-directory)
-              converted-directory)
-            (assoc-default 'line line)
-            (assoc-default 'column line)
-            (assoc-default 'message line))))
-
+  (let* ((converted-directory (replace-regexp-in-string "\\\\" "/" (assoc-default 'filename line)))
+         (parts (split-string converted-directory "!"))
+         (filename (replace-regexp-in-string
+                    eclim--compressed-urls-regexp "" (first parts)))
+         (filename-in-dir (if directory
+                (replace-regexp-in-string (concat (regexp-quote directory) "/?")
+                                          "" filename)
+              filename)))
+    (if (cdr parts)
+        ;; Just put the jar path, since there's no easy way to instruct
+        ;; compile-mode to go into an archive. Better than nothing.
+        ;; TODO: revisit when an archive file-handler shows up somewhere.
+        (format "%s:1: %s\n" filename-in-dir (assoc-default 'message line))
+      (format "%s:%d:%d:%s\n"
+              filename-in-dir
+              (assoc-default 'line line)
+              (assoc-default 'column line)
+              (assoc-default 'message line)))))
+  
 (defun eclim--visit-declaration (line)
   (ring-insert find-tag-marker-ring (point-marker))
   (eclim--find-file (assoc-default 'filename line))


### PR DESCRIPTION
…ues/250

The fix was twofold:
1) Fix regexp to allow jar:file:///Users...
2) Remove explicit filtering of results against archives. There was code to
handle them, but it had been explicitly disabled presumably because of the
problem above, which made it behave rather badly.

This works beautifully when source jars if present, including all of the
SDK. It also works with class files and autodisass-java-bytecode , though
personally I don't find that very useful; better than bytecode, I suppose.