### PR TITLE
Default accepted file regexps should all be extensions (end-of-string).

### DIFF
--- a/eclim.el
+++ b/eclim.el
@@ -506,7 +506,7 @@ for example."
     (remove-hook 'after-save-hook 'eclim--after-save-hook 't)))
 
 (defcustom eclim-accepted-file-regexps
-  '("\\.java" "\\.js" "\\.xml" "\\.rb" "\\.groovy" "\\.php" "\\.c" "\\.cc" "\\.h" "\\.scala")
+  '("\\.java$" "\\.js$" "\\.xml$" "\\.rb$" "\\.groovy$" "\\.php$" "\\.c$" "\\.cc$" "\\.h$" "\\.scala$")
   "List of regular expressions that are matched against filenames
 to decide if eclim should be automatically started on a
 particular file. By default all files part of a project managed


### PR DESCRIPTION
The biggest offender for me was that eclim-accepted would trigger on autosave
files (#Foo.java#), which in turn tripped up eclimd with an error.

But in general:  (eclim--accepted-filename-p "hello.csv") -> t can't be right.