### PR TITLE
Completion: do not refresh problems while inserting the choice.

### DIFF
--- a/eclim-completion.el
+++ b/eclim-completion.el
@@ -221,12 +221,13 @@ buffer."
         (backward-char)))))
 
 (defun eclim--completion-action (beg end)
-  (case major-mode
-    ('java-mode (eclim--completion-action-java beg end))
-    ('groovy-mode (eclim--completion-action-java beg end))
-    ((c-mode c++-mode) (eclim--completion-action-java beg end))
-    ('nxml-mode (eclim--completion-action-xml beg end))
-    (t (eclim--completion-action-default))))
+  (let ((eclim--is-completing t)) ;; an import should not refresh problems
+    (case major-mode
+      ('java-mode (eclim--completion-action-java beg end))
+      ('groovy-mode (eclim--completion-action-java beg end))
+      ((c-mode c++-mode) (eclim--completion-action-java beg end))
+      ('nxml-mode (eclim--completion-action-xml beg end))
+      (t (eclim--completion-action-default)))))
 
 (defun eclim--render-doc (str)
   "Performs rudimentary rendering of HTML elements in


### PR DESCRIPTION
The insertion can result in an import, which is a roundtrip to Eclipse.
More often than not, the code is in bad shape at that point and it's
annoying to have it underlined as you're writing it.