### PR TITLE
Completion: fix up corner cases in yas template computation.

### DIFF
--- a/tests/completion-tests.el
+++ b/tests/completion-tests.el
@@ -1,0 +1,18 @@
+(ert-deftest completion-yasnippet-convert ()
+  ;; Nested params should *not* be nested templates.
+  (should (equal (eclim--completion-yasnippet-convert
+                  "addAll(Collection<? super Object> c, T... elements)")
+                 "addAll(${Collection<? super Object> c}, ${T... elements})"))
+  ;; Corner case: no argument.
+  (should (equal (eclim--completion-yasnippet-convert "toString()")
+                 "toString()"))
+
+  ;; Basic cases.
+  (should (equal (eclim--completion-yasnippet-convert
+                  "printf(Locale l, String format, Object... args)")
+                 "printf(${Locale l}, ${String format}, ${Object... args})"))
+  (should (equal (eclim--completion-yasnippet-convert "HashMap<K,V>")
+                 "HashMap<${K}, ${V}>"))
+
+  )
+


### PR DESCRIPTION
One was that nested parameters created a nested template, which did not
make sense (filling template args before erasing the template altogether);
it did not seem intended. The other was an empty arg list.

Instead, use replace-regexp-in-string which takes care of some ugly
details, and count levels to make sure we replace only on first.

Added a test. The previous code fails the first two assertions.