### PR TITLE
Completion: allow the user to customize insertion.

### DIFF
--- a/tests/completion-tests.el
+++ b/tests/completion-tests.el
@@ -16,3 +16,16 @@
 
   )
 
+(ert-deftest completion-insert-empty-usable ()
+  (let ((eclim-insertion-functions '(eclim-completion-insert-empty)))
+    (cl-letf (((symbol-function 'eclim-java-import) #'ignore))
+      (with-temp-buffer
+        (insert "method(String arg1, List<String> arg2) - some.Class")
+        (eclim--completion-action-java (line-beginning-position) (point))
+        (should (equal (thing-at-point 'line) "method()"))
+        (should (looking-at ")"))
+        (erase-buffer)
+        (insert "method2()")
+        (should (equal (thing-at-point 'line) "method2()"))
+        (should (eolp))
+        ))))


### PR DESCRIPTION
I think yas is problematic for completion because:
* Completion begins by spitting out a potentially long method signature
* Aborting from yas can't resume, so you're left with above
* The code can be in a non-sensical (for Eclipse) state for quite
a long time. This can prevent further coding aids.
* Yas is intrusive and wants to be a minor mode everywhere.

The default insertion is hardly better. So one should at least have the
option to do something different. I put in a simple (and sample)
alternative that simply erases arguments, which is already an improvement,
but I have something better for the next commit.