### PR TITLE
make emacs can navigate codes in a jar file like vim did.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Development has moved to https://github.com/emacs-eclim/emacs-eclim
+
 [![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
 [![Build Status](https://travis-ci.org/emacs-eclim/emacs-eclim.svg?branch=master)](https://travis-ci.org/emacs-eclim/emacs-eclim)
 [![MELPA](http://melpa.org/packages/emacs-eclim-badge.svg)](http://melpa.org/#/emacs-eclim)

--- a/eclim.el
+++ b/eclim.el
@@ -121,7 +121,7 @@ in the current workspace."
     ("utf-8-emacs-unix" . "utf-8")))
 
 (defvar eclim--compressed-urls-regexp
-  "^\\(\\(?:jar\\|file\\|zip\\):\\(?:file:\\)?//\\)")
+    "^\\(\\(?:jar\\|file\\|zip\\):\\(?:file:\\)?//\\)")
 (defvar eclim--compressed-file-path-replacement-regexp "\\\\")
 (defvar eclim--compressed-file-path-removal-regexp "^/")
 

--- a/eclim.el
+++ b/eclim.el
@@ -437,7 +437,7 @@ FILENAME is given, return that file's  project name instead."
       (setq eclim--project-current-file
             (eclim/execute-command "project_link_resource" ("-f" buffer-file-name)))
       ;; command archive_read will extract archive file to /tmp directory, which is out of current project directory.
-      buffer-file-name))
+      (and buffer-file-name (gethash buffer-file-name eclim-projects-for-archive-file) buffer-file-name)))
 
 (defun eclim--byte-offset (&optional text)
   ;; TODO: restricted the ugly newline counting to dos buffers => remove it all the way later

--- a/eclim.el
+++ b/eclim.el
@@ -373,7 +373,7 @@ FILENAME is given, return that file's  project name instead."
         (goto-char (point-min))
         (kill-buffer old-buffer)))))
 
-(defvar eclim-projects-for-archive-file (make-hash-table :test 'equal)) 
+(defvar eclim-projects-for-archive-file (make-hash-table :test 'equal))
 (defun eclim-java-archive-file (file)
   (let ((eclim-auto-save nil))
     (eclim/with-results tmp-file ("archive_read" ("-f" file))


### PR DESCRIPTION
I know that there is a solution here:
[https://github.com/emacs-eclim/emacs-eclim/pull/23](https://github.com/emacs-eclim/emacs-eclim/pull/23)

but it has issue when do a java_search in the file belongs to a archive file.

VIM has no such issue and I fixed it by the way of VIM has did.

Now it can do recursive java_search in source file belongs to a archive file without any issue.