### PR TITLE
Fix package descriptor file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
 [![Build Status](https://travis-ci.org/emacs-eclim/emacs-eclim.svg?branch=master)](https://travis-ci.org/emacs-eclim/emacs-eclim)
-[![MELPA](http://melpa.org/packages/emacs-eclim-badge.svg)](http://melpa.org/#/emacs-eclim)
-[![MELPA Stable](http://stable.melpa.org/packages/emacs-eclim-badge.svg)](http://stable.melpa.org/#/emacs-eclim)
+[![MELPA](http://melpa.org/packages/emacs-eclim-badge.svg)](http://melpa.org/#/eclim)
+[![MELPA Stable](http://stable.melpa.org/packages/emacs-eclim-badge.svg)](http://stable.melpa.org/#/eclim)
 
 ## Overview
 
@@ -41,7 +41,7 @@ number. You can see and download previous releases
 1. Install emacs-eclim. You have two options:
    * Installation from the [MELPA][melpa] package archive. Just add
    the archive to `package-archives` if you haven't already, and then
-   install emacs-eclim with the `package-install` command.
+   install the "eclim" package with the `package-install` command.
    * Manual installation from GitHub.
        1. (`git clone git://github.com/senny/emacs-eclim.git`)
        1. Add `(add-to-list 'load-path "/path/to/emacs-eclim/")` to your startup script.

--- a/eclim-pkg.el
+++ b/eclim-pkg.el
@@ -1,4 +1,4 @@
-(define-package "emacs-eclim" "0.3"
+(define-package "eclim" "0.3"
   "An interface to the Eclipse IDE."
   '((dash "2.11.0")
     (json "1.2")

--- a/tests/emacs-eclim-linter-init.el
+++ b/tests/emacs-eclim-linter-init.el
@@ -18,13 +18,13 @@
 (condition-case err
     (let* ((pkg-info
             (with-temp-buffer
-              (insert-file-contents "emacs-eclim-pkg.el")
+              (insert-file-contents "eclim-pkg.el")
               (goto-char (point-min))
               (read (current-buffer))))
            (name (cadr pkg-info))
            (needed-packages (cadr (nth 4 pkg-info))))
-      (assert (equal name "emacs-eclim"))
-      (message "Loaded emacs-eclim-pkg.el")
+      (assert (equal name "eclim"))
+      (message "Loaded eclim-pkg.el")
       (message "Installing dependencies: %S" needed-packages)
       (if (every #'pkg-installed-p needed-packages)
           (message "All dependencies present.")


### PR DESCRIPTION
As part of fixing up the MELPA recipes, the package name needs to change from `emacs-eclim` to `eclim`: this PR updates the README and package descriptor file accordingly.
