### PR TITLE
Add Hombrew Cask Eclipse directory

### DIFF
--- a/eclim-common.el
+++ b/eclim-common.el
@@ -97,7 +97,8 @@
 (defvar eclim--project-natures-cache nil)
 
 (defcustom eclim-eclipse-dirs '("/Applications/eclipse" "/usr/lib/eclipse"
-                                "/usr/local/lib/eclipse" "/usr/share/eclipse")
+                                "/usr/local/lib/eclipse" "/usr/share/eclipse"
+                                "/Applications/Eclipse.app/Contents/Eclipse/")
   "Path to the eclipse directory"
   :type '(sexp)
   :group 'eclim)


### PR DESCRIPTION
This is where the Eclipse directory is located when Eclipse was installed using `brew
cask install eclipse-java`.