### PR TITLE
Allow tests that require eclim executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ LOAD_PATH := -L .
 EMACS_OPTS :=
 EMACS_BATCH := $(EMACS) -Q -batch -L . $(EMACS_OPTS)
 TEST_LOAD_FILES = -l test/test-helper.el
+TEST_ECLIPSE_DIR = nil
 RUN_EMACS :=
 
 # Program availability
@@ -31,7 +32,7 @@ init:
 	$(CASK) update
 
 test:
-	$(RUN_EMACS) $(TEST_LOAD_FILES) -f eclim-run-tests
+	$(RUN_EMACS) $(TEST_LOAD_FILES) --eval '(eclim-run-tests $(TEST_ECLIPSE_DIR))'
 
 lint: $(EL_FILES)
 	$(RUN_EMACS) $(TEST_LOAD_FILES) -f eclim-lint-files $(EL_FILES)

--- a/test/eclimd-test.el
+++ b/test/eclimd-test.el
@@ -1,0 +1,40 @@
+;;; eclimd-test.el --- Tests for eclimd.el           -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2017  Luis Gerhorst
+
+;; Author: Luis Gerhorst
+;; Keywords: java, eclipse, eclim
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tests for functions controling eclimd.
+
+;;; Code:
+
+(require 'eclimd)
+(require 'eclim-common)
+
+(ert-deftest eclim-connected-after-sync-start-eclimd ()
+  :tags '(:eclim-executable-required)
+  (unwind-protect
+      (progn
+        (let ((eclimd-wait-for-process t))
+          (start-eclimd eclimd-default-workspace)
+          (should (eclim--connected-p))))
+    (stop-eclimd)))
+
+(provide 'eclimd-test)
+;;; eclimd-test.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -64,16 +64,30 @@
      (let ((debug-on-error t))
        (elisp-lint-files-batch)))))
 
-(defun eclim-run-tests ()
-  "Main entry point for linter."
+(defun eclim-run-tests (&optional eclipse-dir)
+  "Main entry point for test runner."
+  (when eclipse-dir
+    (setq eclim-eclipse-dirs (list eclipse-dir)))
+
   (eclim-emacs-init
    (lambda ()
      (let ((tests (directory-files "./test" t "test.el")))
        (while tests
          (load-file (car tests))
          (setq tests (cdr tests))))
-     (let ((debug-on-error t))
-       (ert-run-tests-batch-and-exit)))))
+
+     ;; File in which `eclim-executable' is set:
+     (require 'eclim-common)
+
+     (let ((debug-on-error t)
+           (test-selector (if eclim-executable
+                              t
+                            (message "Warning: No eclim executable found. \
+Supply Eclipse directory when testing:
+   make test TEST_ECLIPSE_DIR='\"/my/local/eclipse/\"'
+   Skipping tests that require the eclim executable.")
+                            '(not (tag :eclim-executable-required)))))
+       (ert-run-tests-batch-and-exit test-selector)))))
 
 
 ;;; test-helper.el ends here


### PR DESCRIPTION
This at least allows running tests that use the eclim executables locally. I tried making it work on Travis CI but the problem was that I could not get Eclipse to install (you have to run a installer now which requires a GUI), here's how far I have come:

```
install:
  - cask install
  - cask update
  - cd /tmp
  - mkdir /home/travis/opt && wget http://ftp.fau.de/eclipse/oomph/epp/neon/R2a/eclipse-inst-linux64.tar.gz -O eclipse.tar.gz && tar -xf eclipse.tar.gz -C /home/travis/opt
# TODO: Run installer now or somehow get eclipse launcher jar, here's how it fails: https://travis-ci.org/luisgerhorst/emacs-eclim/jobs/189469714
  - wget https://github.com/ervandew/eclim/releases/download/2.6.0/eclim_2.6.0.jar -O eclim.jar && java -Dvim.skip=true -Declipse.home=/home/travis/opt/eclipse -jar eclim.jar install
  - cd -
```