### PR TITLE
Fix documentation

### DIFF
--- a/eclim-completion.el
+++ b/eclim-completion.el
@@ -38,24 +38,6 @@
 (require 'eclim-common)
 (require 'eclim-java)
 
-(defun eclim--completion-candidate-type (candidate)
-  "Returns the type of a candidate."
-  (assoc-default 'type candidate))
-
-(defun eclim--completion-candidate-class (candidate)
-  "Returns the class name of a candidate."
-  (assoc-default 'info candidate))
-
-(defun eclim--completion-candidate-doc (candidate)
-  "Returns the documentation for a candidate."
-  (assoc-default 'menu candidate))
-
-(defun eclim--completion-candidate-package (candidate)
-  "Returns the package name of a candidate."
-  (let ((doc (eclim--completion-candidate-doc candidate)))
-    (when (string-match "\\(.*\\)\s-\s\\(.*\\)" doc)
-      (match-string 2 doc))))
-
 (defvar eclim--completion-candidates nil)
 
 (defvar eclim-insertion-functions nil

--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -34,17 +34,17 @@
 (eval-when-compile (require 'eclim-macros))
 
 (defgroup eclim-problems nil
-  "Problems: settings for displaying the problems buffer and highlighting errors in code."
+  "Settings for displaying problems in code and the problems buffer."
   :group 'eclim)
 
 (defface eclim-problems-highlight-error-face
   '((t (:underline "red")))
-  "Face used for highlighting errors in code"
+  "Face used for highlighting errors in code."
   :group 'eclim-problems)
 
 (defface eclim-problems-highlight-warning-face
   '((t (:underline "orange")))
-  "Face used for highlighting errors in code"
+  "Face used for highlighting warnings in code."
   :group 'eclim-problems)
 
 (defvar eclim-problems-mode-hook nil)
@@ -159,8 +159,9 @@
     (eclim--problem-goto-pos p)))
 
 (defun eclim-problems-correct ()
-  "Pops up a suggestion for the current correction. This can be
-invoked in either the problems buffer or a source code buffer."
+  "Show a suggestion for the current correction.
+This can be invoked in either the problems buffer or a
+source code buffer."
   (interactive)
   (let ((p (eclim--problems-get-current-problem)))
     (unless (string-match "\\.\\(groovy\\|java\\)$" (cdr (assoc 'filename p)))
@@ -181,22 +182,20 @@ invoked in either the problems buffer or a source code buffer."
   (not (eclim--warning-filterp x)))
 
 (defun eclim--get-problems-buffer ()
-  "Gets the existing problems buffer.
-Returns nil if no problems buffer exists."
+  "Return the existing problems buffer, or nil of none exists."
   (get-buffer eclim--problems-buffer-name))
 
 (defun eclim--get-problems-buffer-create ()
-  "Return the eclim problems buffer.
-If the buffer does not exist, it is created."
+  "Return the eclim problems buffer, creating one if none exists."
   (or (eclim--get-problems-buffer)
       (progn
         (eclim--problems-mode-init t)
         (eclim--get-problems-buffer))))
 
 (defun eclim--problems-mode-init (&optional quiet)
-  "Create and initialize the eclim problems buffer. If the
-argument QUIET is non-nil, open the buffer in the background
-without switching to it."
+  "Create and initialize the eclim problems buffer.
+If the optional argument QUIET is non-nil, open the buffer
+in the background without switching to it."
   (let ((buf (get-buffer-create eclim--problems-buffer-name)))
     (save-excursion
       (setq eclim--problems-project (eclim-project-name))
@@ -209,14 +208,18 @@ without switching to it."
         (switch-to-buffer buf))))
 
 (defun eclim-problems ()
-  "Show current compilation problems in a separate window."
+  "Switch to and refresh the problems buffer.
+If the problems buffer does not exist yet, it is created."
   (interactive)
   (if (eclim-project-name)
       (eclim--problems-mode-init)
     (error "Could not figure out the current project. Is this an eclim managed buffer?")))
 
 (defun eclim-problems-open ()
-  "Opens a new (emacs) window inside the current frame showing the current project compilation problems"
+  "Switch to the problems buffer in a new Emacs window.
+The new window will be in the current frame.  The problems
+buffer will be updated to show that latest compilation
+problems."
   (interactive)
   (let ((w (selected-window)))
     (select-window (split-window nil (round (* (window-height w) 0.75)) nil))
@@ -265,9 +268,9 @@ without switching to it."
   (eclim-problems-previous t))
 
 (defun eclim-problems-compilation-buffer ()
-  "Creates a compilation buffer from eclim error messages. This
-is convenient as it lets the user navigate between errors using
-`next-error' (\\[next-error])."
+  "Create a compilation buffer from eclim problems.
+This is convenient as it lets the user navigate between
+errors using `next-error' (\\[next-error])."
   (interactive)
   (let ((filecol-size (eclim--problems-filecol-size))
         (project-directory (concat (eclim--project-dir) "/"))
@@ -338,8 +341,10 @@ is convenient as it lets the user navigate between errors using
    (eclim--filter-problems "w" t (buffer-file-name (current-buffer)) eclim--problems-list)))
 
 (defun eclim-problems-next-same-file (&optional up)
-  "Moves to the next problem in the current file, with wraparound. If UP
-or prefix arg, moves to previous instead; see `eclim-problems-prev-same-file'."
+  "Move to the next problem in the current file, with wraparound.
+If UP is provided and non-nil, move to the previous problem
+instead.  In an interactive call, UP is the prefix argument.
+See `eclim-problems-prev-same-file'."
   (interactive "P")
   ;; This seems pretty inefficient, but it's fast enough. Would be even
   ;; more inefficient if we didn't assume problems were sorted.
@@ -366,14 +371,13 @@ or prefix arg, moves to previous instead; see `eclim-problems-prev-same-file'."
              (elt problems-file 0))))))
 
 (defun eclim-problems-prev-same-file ()
-  "Moves to the previous problem in the same file, with wraparound."
+  "Move to the previous problem in the current file, with wraparound."
   (interactive)
   (eclim-problems-next-same-file t))
 
 
 (defun eclim-problems-modeline-string ()
-  "Returns modeline string with additional info about
-problems for current file"
+  "Return a modeline string summarizing problems in the current file."
   (concat (format ": %s/%s"
                   (eclim--count-current-errors)
                   (eclim--count-current-warnings))

--- a/eclim.el
+++ b/eclim.el
@@ -50,8 +50,6 @@
   "Interface to the Eclipse IDE."
   :group 'tools)
 
-(defvar-local eclim--project-name nil)
-
 (defun eclim-toggle-print-debug-messages ()
   (interactive)
   (message "Debug messages %s."
@@ -87,15 +85,6 @@ strings and will be called on completion."
                                   (funcall handler (eclim--parse-result (buffer-substring 1 (point-max)))))
                               (kill-buffer buf)))))
             (set-process-sentinel proc sentinel)))))))
-
-(defvar eclim--default-args
-  "Maps eclim command-line arguments to expressions that evaluate to the args default value."
-  '(("-n" . (eclim-project-name))
-    ("-p" . (or (eclim-project-name) (error "Could not find eclipse project for %s" (buffer-name (current-buffer)))))
-    ("-e" . (eclim--current-encoding))
-    ("-f" . (eclim--project-current-file))
-    ("-o" . (eclim--byte-offset))
-    ("-s" . "project")))
 
 ;; Commands
 

--- a/eclim.el
+++ b/eclim.el
@@ -50,13 +50,6 @@
   "Interface to the Eclipse IDE."
   :group 'tools)
 
-(defcustom eclim-limit-search-results t
-  "Determines if code search results should be limited to files
-in the current workspace."
-  :group 'eclim
-  :type '(choice (const :tag "Off" nil)
-                 (const :tag "On" t)))
-
 (defvar-local eclim--project-name nil)
 
 (defun eclim-toggle-print-debug-messages ()

--- a/eclim.el
+++ b/eclim.el
@@ -57,17 +57,22 @@
                "on" "off")))
 
 (defun eclim-quit-window (&optional kill-buffer)
-  "Bury the buffer and delete its window.  With a prefix argument, kill the
-buffer instead."
+  "Bury the buffer and delete its window.
+With prefix argument KILL-BUFFER non-nil, kill the buffer
+instead of burying it."
   (interactive "P")
   (quit-window kill-buffer (selected-window)))
 
 (defvar eclim--currently-running-async-calls nil)
 
 (defun eclim--call-process-async (callback &rest args)
-  "Like `eclim--call-process', but the call is executed
-asynchronously.  CALLBACK is a function that accepts a list of
-strings and will be called on completion."
+  "Call eclim asynchronously with the supplied arguments.
+CALLBACK is a function that accepts a list of strings and
+will be called on completion.  ARGS are the strings to be
+passed as command line arguments to eclim.
+
+This function is just like `eclim--call-process' except that
+it is asynchronous."
   (let ((handler callback)
         (cmd (eclim--make-command args)))
     (when (not (cl-find cmd eclim--currently-running-async-calls :test #'string=))
@@ -101,13 +106,13 @@ strings and will be called on completion."
                                  t)))
 
 (defun eclim-find-file-path-strict (filename &optional project directory)
-  "Locates a file (basename) in Eclipse. If PROJECT is a string,
-searches only that project; if nil, the project of the current
-file. If t, searches all Eclipse projects. If DIRECTORY is
-specified, returns only files that are under that
-directory. Returns a list of matching absolute paths; possibly
-empty. This can be used to help resolve exception stack traces,
-for example."
+  "Locate a file with the basename FILENAME in Eclipse.
+If PROJECT is a string, searches only that project; if nil,
+the project of the current file; if t, searches all Eclipse
+projects.  If DIRECTORY is specified, returns only files
+that are under that directory.  Returns a list of matching
+absolute paths; possibly empty.  This can be used to help
+resolve exception stack traces, for example."
   (let* ((results (apply #'eclim--call-process "locate_file"
                         "-p" (regexp-quote filename)
                          (if (eq project t)
@@ -176,17 +181,17 @@ that is not organized in a Eclipse project. Create a new project? "))
   eclim--enable-for-accepted-files-in-project)
 
 (defvar eclim--enable-for-accepted-files-in-project-running nil
-  "Used to prevent recursive calls to `global-eclim-mode''s turn-on function.
-Recursive calls are possible because `eclimd--ensure-started' may
-create a comint buffer for which Emacs checks whether
-`eclim-mode' should be enabled.")
+  "Used to prevent recursive calls to function `global-eclim-mode'.
+Such recursive calls are possible because
+`eclimd--ensure-started' may create a comint buffer for
+which Emacs checks whether `eclim-mode' should be enabled.")
 
 (defun eclim--enable-for-accepted-files-in-project ()
-  "Enable `eclim-mode' in accepted files that belong to a Eclipse project.
+  "Enable `eclim-mode' in accepted files that belong to a project.
 A file is accepted if it's name is matched by any of
-`eclim-accepted-file-regexps' elements. Note that in order to
-determine if a file is managed by a project, eclimd is required
-to be running and will thus be autostarted."
+`eclim-accepted-file-regexps' elements.  Note that in order
+to determine if a file is managed by a project, eclimd is
+required to be running and will thus be autostarted."
   ;; Errors here can REALLY MESS UP AN EMACS SESSION. Can't emphasize enough.
   (ignore-errors
     (unless eclim--enable-for-accepted-files-in-project-running


### PR DESCRIPTION
A lot of the documentation has now been fixed, and missing documentation has been added. I focused on these main files: `eclim-common.el`, `eclim-completion.el`, `eclim-macros.el`, `eclim-problems.el`, `eclim.el` and `eclimd.el`.

There were also some unused internal functions and redundant variable declarations which I thought should be removed immediately.

I did not update or add any tests for these changes, since that would be a lot of work and can be done separately.