### PR TITLE
fix javadoc format to remove <code> tags for links

### DIFF
--- a/eclim-java.el
+++ b/eclim-java.el
@@ -836,7 +836,7 @@ browser."
         link placeholder text href)
     (dotimes (i (length links))
       (setq link (aref links i))
-      (setq text (cdr (assoc 'text link)))
+      (setq text (replace-regexp-in-string "</?code>" "" (cdr (assoc 'text link))))
       (setq href (cdr (assoc 'href link)))
       (setq placeholder (format "|%s[%s]|" text i))
       (goto-char (point-min))


### PR DESCRIPTION
Sometimes `java_element_doc` returns links whose text is  wrapped in 
`<code>...</code>` blocks. This messes up the formatting function so it
misses creating the appropriate links in the *java doc* buffer. This commit
removes the code blocks from link text.