### PR TITLE
General cleanup - format javadocs, pass linting, remove cl deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: emacs-lisp
+language: generic
 sudo: false
 dist: trusty
 env:

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,27 @@
 # makefie for emacs-eclim
 
-EL_FILES := $(sort $(wildcard *.el))
-ELC_FILES := $(EL_FILES:.el=.elc)
+EL_FILES        := $(sort $(wildcard *.el))
+ELC_FILES       := $(EL_FILES:.el=.elc)
 
-EMACS := emacs
-CASK := cask
-LOAD_PATH := -L .
-EMACS_OPTS :=
-EMACS_BATCH := $(EMACS) -Q -batch -L . $(EMACS_OPTS)
+EMACS           := emacs
+CASK            := cask
+LOAD_PATH       := -L .
+EMACS_OPTS      :=
+EMACS_BATCH     := $(EMACS) -Q -batch -L . $(EMACS_OPTS)
+
 LINT_LOAD_FILES = -l maint/eclim-lint.el
+LINT_FILES      = $(filter-out %-pkg.el,${EL_FILES})
 
 # Program availability
 ifdef CASK
-RUN_EMACS = $(CASK) exec $(EMACS_BATCH)
-HAVE_CASK := $(shell sh -c "command -v $(CASK)")
+RUN_EMACS       = $(CASK) exec $(EMACS_BATCH)
+HAVE_CASK       := $(shell sh -c "command -v $(CASK)")
 ifndef HAVE_CASK
 $(warning "$(CASK) is not available.  Please run make help")
 endif
 endif
 
-VPATH := .
+VPATH           := .
 
 all: test
 
@@ -33,8 +35,8 @@ test:
 specs:
 	$(CASK) exec buttercup -L . -L ./test/specs
 
-lint: $(EL_FILES)
-	$(RUN_EMACS) $(LINT_LOAD_FILES) -f eclim-lint-files $(EL_FILES)
+lint: $(LINT_FILES)
+	$(RUN_EMACS) $(LINT_LOAD_FILES) -f eclim-lint-files $(LINT_FILES)
 
 package-lint: $(EL_FILES)
 	$(RUN_EMACS) $(LINT_LOAD_FILES) -f eclim-package-lint $(EL_FILES)

--- a/ac-emacs-eclim.el
+++ b/ac-emacs-eclim.el
@@ -83,8 +83,8 @@
 ;;;###autoload
 (defun ac-emacs-eclim-config ()
   (add-hook 'java-mode-hook 'ac-emacs-eclim-java-setup)
-  (add-hook 'groovy-mode-hook '(lambda ()
-                                 (add-to-list 'ac-sources 'ac-source-emacs-eclim)))
+  (add-hook 'groovy-mode-hook
+            '(lambda () (add-to-list 'ac-sources 'ac-source-emacs-eclim)))
   (add-hook 'xml-mode-hook 'ac-emacs-eclim-xml-setup)
   (add-hook 'nxml-mode-hook 'ac-emacs-eclim-xml-setup)
   (add-hook 'php-mode-hook 'ac-emacs-eclim-php-setup)

--- a/company-emacs-eclim.el
+++ b/company-emacs-eclim.el
@@ -30,7 +30,7 @@
 (require 'eclim-completion)
 (require 'eclim-java)
 (require 'company)
-(require 'cl-lib)
+(eval-when-compile (require 'cl-lib))
 
 (defcustom company-emacs-eclim-ignore-case t
   "If t, case is ignored in completion matches."
@@ -40,15 +40,16 @@
 
 ;;;###autoload
 (defun company-emacs-eclim-setup ()
-  "Convenience function that adds company-emacs-eclim to the list
-  of available company backends."
+  "Convenience function that adds ‘company-emacs-eclim’ to the list \
+of available company backends."
   (setq company-backends
         (cons 'company-emacs-eclim
               (cl-remove-if (lambda (b) (cl-find b '(company-nxml company-eclim)))
                             company-backends))))
 
 (defun company-emacs-eclim--before-prefix-in-buffer (prefix)
-  "Search for the text before prefix that may be included as part of completions"
+  "Search for the text before PREFIX that may be included as part of \
+completions."
   (ignore-errors
     (save-excursion
       (let ((end (progn
@@ -64,19 +65,20 @@
         (buffer-substring-no-properties start end)))))
 
 (defun company-emacs-eclim--candidates (prefix)
-  (let ((before-prefix-in-buffer (company-emacs-eclim--before-prefix-in-buffer prefix)))
+  (let ((before-prefix-in-buffer
+         (company-emacs-eclim--before-prefix-in-buffer prefix)))
     (cl-labels
         ((annotate (str)
-                   (if (string-match "(" str)
-                       (propertize
-                        (substring str 0 (match-beginning 0)) 'eclim-meta str)
-                     str))
+           (if (string-match "(" str)
+               (propertize
+                (substring str 0 (match-beginning 0)) 'eclim-meta str)
+             str))
          (without-redundant-prefix (str)
-                                   (if (and before-prefix-in-buffer
-                                            (> (length before-prefix-in-buffer) 0)
-                                            (string-prefix-p before-prefix-in-buffer str))
-                                       (substring str (length before-prefix-in-buffer))
-                                     str)))
+           (if (and before-prefix-in-buffer
+                    (> (length before-prefix-in-buffer) 0)
+                    (string-prefix-p before-prefix-in-buffer str))
+               (substring str (length before-prefix-in-buffer))
+             str)))
       (mapcar
        (lambda (candidate)
          (annotate (without-redundant-prefix candidate)))
@@ -92,8 +94,10 @@
       (substring str (match-beginning 0)))))
 
 ;;;###autoload
-(defun company-emacs-eclim (command &optional arg &rest ignored)
-  "`company-mode' back-end for Eclim completion"
+(defun company-emacs-eclim (command &optional arg &rest _ignored)
+  "Eclim `company' completion backend.
+
+See `company' for explanation of COMMAND and ARG."
   (interactive (list 'interactive))
   (cl-case command
     (interactive (company-begin-backend 'company-emacs-eclim))

--- a/eclim-ant.el
+++ b/eclim-ant.el
@@ -26,7 +26,7 @@
 ;;
 ;;; Commentary:
 ;;
-;;* Eclim Ant
+;;; Code:
 
 (require 'eclim-common)
 
@@ -36,12 +36,12 @@
 (define-key eclim-mode-map (kbd "C-c C-e a v") 'eclim-ant-validate)
 
 (defgroup eclim-ant nil
-  "Build java projects using Apache Ant"
+  "Build java projects using Apache Ant."
   :group 'eclim)
 
 (defcustom eclim-ant-directory ""
-  "This variable contains the location, where the main buildfile is
-stored. It is used globally for all eclim projects."
+  "This variable contains the location, where the main buildfile is stored.
+It is used globally for all eclim projects."
   :group 'eclim-ant
   :type 'directory)
 
@@ -62,10 +62,12 @@ stored. It is used globally for all eclim projects."
   (when (null eclim--ant-target-cache)
     (setq eclim--ant-target-cache (make-hash-table :test 'equal)))
   (or (gethash buildfile eclim--ant-target-cache)
-      (puthash buildfile (eclim/ant-target-list project buildfile) eclim--ant-target-cache)))
+      (puthash buildfile (eclim/ant-target-list project buildfile)
+               eclim--ant-target-cache)))
 
 (defun eclim--ant-read-target (project buildfile)
-  (eclim--completing-read "Target: " (append (eclim--ant-targets project buildfile) nil)))
+  (eclim--completing-read
+   "Target: " (append (eclim--ant-targets project buildfile) nil)))
 
 (defun eclim/ant-validate (project buildfile)
   (eclim--check-project project)
@@ -78,8 +80,9 @@ stored. It is used globally for all eclim projects."
   (eclim--call-process "ant_targets" "-p" project "-f" buildfile))
 
 (defun eclim-ant-clear-cache ()
-  "Clear the cached ant target list. This can be usefull when the
-buildfile for the current project has changed and needs to be updated"
+  "Clear the cached ant target list.
+This can be usefull when the buildfile for the current project has changed and
+needs to be updated."
   (interactive)
   (setq eclim--ant-target-cache nil))
 
@@ -99,9 +102,9 @@ buildfile for the current project has changed and needs to be updated"
 ;;   (compilation-mode))
 
 (defun eclim-ant-run (target)
-  "run a specified ant target in the scope of the current project. If
-the function is called interactively the users is presented with a
-  list of all available ant targets."
+  "Run a specified ant TARGET in the scope of the current project.
+If the function is called interactively the users is presented with a list of
+all available ant targets."
   (interactive (list (eclim--ant-read-target (eclim-project-name)
                                              (eclim--ant-buildfile-name))))
   (let ((default-directory (eclim--ant-buildfile-path)))
@@ -109,3 +112,4 @@ the function is called interactively the users is presented with a
     (compile (concat "ant " target))))
 
 (provide 'eclim-ant)
+;;; eclim-ant.el ends here

--- a/eclim-common.el
+++ b/eclim-common.el
@@ -28,10 +28,8 @@
 ;;
 ;;; Code:
 
-
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 (require 'etags)
-(require 'cl-lib)
 (require 'json)
 (require 'arc-mode)
 (require 'popup)
@@ -44,7 +42,7 @@
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "M-TAB") 'eclim-complete)
     map)
-  "The keymap used in `eclim-mode'.")
+  "The keymap used in command `eclim-mode'.")
 
 (defvar eclimd-process nil
   "The active eclimd process.")
@@ -81,7 +79,9 @@ absolute paths.")
 
 (defvar eclim--default-args
   '(("-n" . (eclim-project-name))
-    ("-p" . (or (eclim-project-name) (error "Could not find eclipse project for %s" (buffer-name (current-buffer)))))
+    ("-p" . (or (eclim-project-name)
+                (error "Could not find eclipse project for %s"
+                       (buffer-name (current-buffer)))))
     ("-e" . (eclim--current-encoding))
     ("-f" . (eclim--project-current-file))
     ("-o" . (eclim--byte-offset))
@@ -158,8 +158,8 @@ ID \"org.eclipse.jdt.core.javanature\".")
   :group 'eclim)
 
 (defcustom eclim-eclimrc nil
-  "The file containing the run commands that Eclim will use when
-invoked. See http://eclim.org/eclimd.html#eclimrc."
+  "The file containing the run commands that Eclim will use when invoked.
+See http://eclim.org/eclimd.html#eclimrc."
   :group 'eclim
   :type 'string)
 
@@ -182,7 +182,8 @@ saved."
   :type '(choice (const :tag "Off" nil)
                  (const :tag "On" t)))
 
-(defcustom eclim-interactive-completion-function (if ido-mode 'ido-completing-read 'completing-read)
+(defcustom eclim-interactive-completion-function
+  (if ido-mode 'ido-completing-read 'completing-read)
   "The function eclim should use to complete interactive choices."
   :group 'eclim
   :type 'function)
@@ -304,7 +305,8 @@ It is an error if PROJECT is not a recognized project name."
   (eclim--call-process "project_info" "-p" project))
 
 (define-error 'eclim--connection-refused-error
-  "Eclim was unable to connect to eclimd. You can start eclimd using M-x start-eclimd")
+  "Eclim was unable to connect to eclimd. You can start eclimd using \
+M-x eclimd-start")
 
 (define-error 'eclim--eclimd-starting-error
   "Eclimd is currently being started. Please wait for it to be ready and retry."
@@ -313,25 +315,30 @@ It is an error if PROJECT is not a recognized project name."
 (defun eclim--parse-result (result)
   "Parse the result of an eclim operation.
 Raises An error if RESULT is not valid JSON."
-  (if (string-match (rx string-start (zero-or-more (any " " "\n" "\t")) string-end) result)
+  (if (string-match
+       (rx string-start (zero-or-more (any " " "\n" "\t")) string-end) result)
       nil
     (condition-case nil
         (json-read-from-string result)
       ('json-readtable-error
        (cond ((string-match "java.io.UnsupportedEncodingException: \\(.*\\)" result)
               (let ((e (match-string 1 result)))
-                (error "Eclim doesn't know how to handle the encoding %s. You can avoid this by
-evaluating (add-to-list 'eclim--file-coding-system-mapping '(\"%s\" . \"<encoding>\"))
-where <encoding> is the corresponding java name for this encoding." e e)))
+                (error "Eclim doesn't know how to handle the encoding %s.  \
+You can avoid this by evaluating
+(add-to-list 'eclim--file-coding-system-mapping '(\"%s\" . \"<encoding>\"))
+where <encoding> is the corresponding java name for this encoding" e e)))
              ((string-match "No command '\\(.*\\)' found" result)
-              (let ((c (assoc-default (match-string 1 result)
-                                      '(("xml_complete" "XML" "Eclipse Web Developer Tools")
-                                        ("groovy_complete" "Groovy" "Eclipse Groovy Development Tools")
-                                        ("ruby_complete" "Ruby" "Eclipse Ruby Development Tools")
-                                        ("c_complete" "C/C++" "Eclipse C/C++ Development Tools")
-                                        ("php_complete" "PHP" "Eclipse PHP Development Tools")
-                                        ("scala_complete" "Scala" "Eclipse Scala Development Tools")))))
-                (if c (error "Eclim was not installed with %s support. Please make sure that %s are installed, then reinstall eclim." (first c) (second c))
+              (let ((c (assoc-default
+                        (match-string 1 result)
+                        '(("xml_complete" "XML" "Eclipse Web Developer Tools")
+                          ("groovy_complete" "Groovy"
+                           "Eclipse Groovy Development Tools")
+                          ("ruby_complete" "Ruby" "Eclipse Ruby Development Tools")
+                          ("c_complete" "C/C++" "Eclipse C/C++ Development Tools")
+                          ("php_complete" "PHP" "Eclipse PHP Development Tools")
+                          ("scala_complete" "Scala"
+                           "Eclipse Scala Development Tools")))))
+                (if c (error "Eclim was not installed with %s support.  Please make sure that %s are installed, then reinstall eclim" (cl-first c) (cl-second c))
                   (error "%s" result))))
              ((string-match ".*Exception: \\(.*\\)" result)
               (error "%s" (match-string 1 result)))
@@ -363,14 +370,16 @@ If the optional argument FILENAME is given, return that
 file's project name.  Otherwise return the current file's
 project name."
   (cl-labels ((get-project-name (file)
-                                (if (not (string= file buffer-auto-save-file-name))
-                                    (eclim/execute-command "project_by_resource" ("-f" file))
-                                  nil)))
+                (if (not (string= file buffer-auto-save-file-name))
+                    (eclim/execute-command "project_by_resource" ("-f" file))
+                  nil)))
     (if filename
         (get-project-name filename)
       (or eclim--project-name
-          (and buffer-file-name (setq eclim--project-name (get-project-name buffer-file-name)))
-          (and buffer-file-name (gethash buffer-file-name eclim-projects-for-archive-file))))))
+          (and buffer-file-name
+               (setq eclim--project-name (get-project-name buffer-file-name)))
+          (and buffer-file-name
+               (gethash buffer-file-name eclim-projects-for-archive-file))))))
 
 (defun eclim--expand-args (args)
   "Supply missing default values for eclim arguments.
@@ -381,15 +390,16 @@ in `eclim--default-args' and used to construct a list.  The
 argument lists are then appended together."
   (mapcar (lambda (arg) (if (numberp arg) (number-to-string arg) arg))
           (cl-loop for arg in args
-                   append (if (stringp arg)
-                              (list arg (eval (cdr (or (assoc arg eclim--default-args)
-                                                       (error "No default value for %s found" arg)))))
-                            (assert (listp arg))
-                            (when arg
-                              (assert (stringp (car arg)))
-                              (assert (or (stringp (cadr arg))
-                                          (numberp (cadr arg)))))
-                            arg))))
+             append (if (stringp arg)
+                        (list arg (eval (cdr
+                                         (or (assoc arg eclim--default-args)
+                                             (error "No default value for %s found" arg)))))
+                      (cl-assert (listp arg))
+                      (when arg
+                        (cl-assert (stringp (car arg)))
+                        (cl-assert (or (stringp (cadr arg))
+                                       (numberp (cadr arg)))))
+                      arg))))
 
 (defun eclim--src-update (&optional save-others)
   "Automatically save the current buffer before calling eclim.
@@ -399,12 +409,16 @@ SAVE-OTHERS is non-nil, any other unsaved Java buffers are
 saved as well."
   (when eclim-auto-save
     (when (buffer-modified-p) (save-buffer)) ;; auto-save current buffer, prompt on saving others
-    (when save-others (save-some-buffers nil (lambda () (string-match "\\.java$" (buffer-file-name)))))))
+    (when save-others (save-some-buffers
+                       nil (lambda () (string-match "\\.java$" (buffer-file-name)))))))
 
 (defun eclim--check-project (project)
   "Throw error if PROJECT is not a recognized project name."
   (let ((projects (or eclim--projects-cache
-                      (setq eclim--projects-cache (mapcar (lambda (p) (assoc-default 'name p)) (eclim/project-list))))))
+                      (setq eclim--projects-cache
+                            (mapcar (lambda (p)
+                                      (assoc-default 'name p))
+                                    (eclim/project-list))))))
     (when (not (assoc-string project projects))
       (error "Invalid project: %s" project))))
 
@@ -429,7 +443,8 @@ of CMD.  Each argument will be expanded using
     (when sync (eclim--src-update))
     (when check
       (ignore-errors
-        (eclim--check-project (if (listp check) (eval (second check)) (eclim-project-name)))))
+        (eclim--check-project (if (listp check) (eval (cl-second check))
+                                (eclim-project-name)))))
     (let ((attrs-before (if sync (file-attributes (buffer-file-name)) nil)))
       (funcall executor (cons cmd expargs)
                (lambda ()
@@ -438,8 +453,10 @@ of CMD.  Each argument will be expanded using
                      (when (and (file-exists-p (buffer-file-name))
                                 attrs-before
                                 (or
-                                 (not (= (second (sixth attrs-before)) (second (sixth attrs-curr)))) ;; mod time
-                                 (not (= (eighth attrs-before) (eighth attrs-curr))))) ;; size time
+                                 (not (= (cl-second (cl-sixth attrs-before))
+                                         (cl-second (cl-sixth attrs-curr)))) ;; mod time
+                                 (not (= (cl-eighth attrs-before)
+                                         (cl-eighth attrs-curr))))) ;; size time
                        (revert-buffer t t t)))))))))
 
 
@@ -449,8 +466,8 @@ of CMD.  Each argument will be expanded using
 
 (defun eclim--project-dir (&optional projectname)
   "Return this project's root directory.
-If the optional argument PROJECTNAME is given, return that
-project's root directory."
+If the optional argument PROJECTNAME is given, return that project's root
+directory."
   (assoc-default 'path (eclim/project-info (or projectname (eclim-project-name)))))
 
 (defun eclim--byte-offset (&optional _text)
@@ -481,44 +498,51 @@ TODO: Remove ugly newline counting altogether."
 
 (defun eclim-executable-find ()
   "Attempt to find the eclim executable in one of `eclim-eclipse-dirs'."
-  (let (file)
-    (dolist (eclipse-root eclim-eclipse-dirs)
-      (and (file-exists-p
-            (setq file (expand-file-name "plugins" eclipse-root)))
-           (setq file (car (last (directory-files file t "^org.eclim_"))))
-           (file-exists-p (setq file (expand-file-name "bin/eclim" file)))
-           (return file)))))
+  (cl-block nil
+    (let (file)
+      (dolist (eclipse-root eclim-eclipse-dirs)
+        (and (file-exists-p
+              (setq file (expand-file-name "plugins" eclipse-root)))
+             (setq file (car (last (directory-files file t "^org.eclim_"))))
+             (file-exists-p (setq file (expand-file-name "bin/eclim" file)))
+             (cl-return file))))))
 
 (defcustom eclim-executable
-  (or (executable-find "eclim") (eclim-homedir-executable-find) (eclim-executable-find))
+  (or (executable-find "eclim")
+      (eclim-homedir-executable-find)
+      (eclim-executable-find))
   "Location of eclim executable."
   :group 'eclim
   :type 'file)
 
 (defun eclim-executable-get-command ()
-  "Returns the Eclim executable command. If \"eclim-eclimrc\" and /
-or \"eclim-nailgun-port\" are defined, then these are appended to
-the command."
+  "Returns the Eclim executable command.
+If \"eclim-eclimrc\" and/or \"eclim-nailgun-port\" are defined, then these
+are appended to the command."
   (when (not eclim-executable)
-    (error "Eclim installation not found. Please set eclim-executable."))
+    (error "Eclim installation not found.  Please set eclim-executable"))
   (let ((command eclim-executable))
     (when eclim-eclimrc (setq command (concat command " -f " eclim-eclimrc)))
-    (when eclim-nailgun-port (setq command (concat command " --nailgun-port " (number-to-string eclim-nailgun-port))))
+    (when eclim-nailgun-port
+      (setq command (concat command " --nailgun-port "
+                            (number-to-string eclim-nailgun-port))))
     command))
 
 (defun eclim--make-command (args)
   "Create a command string that can be executed from the shell.
-The first element in ARGS is the name of the eclim
-operation.  The rest are flags/values to be passed on to
-eclimd."
+The first element in ARGS is the name of the eclim operation.
+The rest are flags/values to be passed on to eclimd."
   (when (not eclim-executable)
-    (error "Eclim installation not found. Please set eclim-executable."))
+    (error "Eclim installation not found.  Please set eclim-executable"))
   (cl-reduce (lambda (a b) (format "%s %s" a b))
-          (append (list (eclim-executable-get-command) "-command" (first args))
-                  (cl-loop for a = (cdr args) then (cdr (cdr a))
-                           for arg = (first a)
-                           for val = (second a)
-                           while arg append (if val (list arg (shell-quote-argument val)) (list arg))))))
+             (append (list
+                      (eclim-executable-get-command) "-command" (cl-first args))
+                     (cl-loop for a = (cdr args) then (cdr (cdr a))
+                        for arg = (cl-first a)
+                        for val = (cl-second a)
+                        while arg append (if val
+                                             (list arg (shell-quote-argument val))
+                                           (list arg))))))
 
 (defun eclim--call-process-no-parse (&rest args)
   "Call eclim using ARGS as command line arguments.
@@ -533,8 +557,11 @@ the output from eclim is returned as a string."
   (or eclim--project-current-file
       (setq eclim--project-current-file
             (eclim/execute-command "project_link_resource" ("-f" buffer-file-name)))
-      ;; command archive_read will extract archive file to /tmp directory, which is out of current project directory.
-      (and buffer-file-name (gethash buffer-file-name eclim-projects-for-archive-file) buffer-file-name)))
+      ;; command archive_read will extract archive file to /tmp directory, which
+      ;; is out of current project directory.
+      (and buffer-file-name
+           (gethash buffer-file-name eclim-projects-for-archive-file)
+           buffer-file-name)))
 
 (defun eclim--current-encoding ()
   "Return the encoding of the current file."
@@ -547,18 +574,21 @@ the output from eclim is returned as a string."
 (defun eclim--find-file (path-to-file)
   "Visit a file identified by PATH-TO-FILE even if it is in an archive."
   (if (not (string-match-p "!" path-to-file))
-      (unless (and (buffer-file-name) (file-equal-p path-to-file (buffer-file-name)))
+      (unless (and (buffer-file-name)
+                   (file-equal-p path-to-file (buffer-file-name)))
         (find-file path-to-file))
     (let* ((parts (split-string path-to-file "!"))
-           (archive-name (replace-regexp-in-string eclim--compressed-urls-regexp "" (first parts)))
-           (file-name (second parts)))
+           (archive-name (replace-regexp-in-string
+                          eclim--compressed-urls-regexp "" (cl-first parts)))
+           (file-name (cl-second parts)))
       (find-file-other-window archive-name)
       (goto-char (point-min))
       (re-search-forward (replace-regexp-in-string
                           eclim--compressed-file-path-removal-regexp ""
-                          (regexp-quote (replace-regexp-in-string
-                                         eclim--compressed-file-path-replacement-regexp
-                                         "/" file-name))))
+                          (regexp-quote
+                           (replace-regexp-in-string
+                            eclim--compressed-file-path-replacement-regexp
+                            "/" file-name))))
       (let ((old-buffer (current-buffer)))
         (archive-extract)
         (goto-char (point-min))
@@ -602,11 +632,12 @@ removed from the beginning of file paths if possible."
   (let* ((converted-directory (replace-regexp-in-string "\\\\" "/" (assoc-default 'filename line)))
          (parts (split-string converted-directory "!"))
          (filename (replace-regexp-in-string
-                    eclim--compressed-urls-regexp "" (first parts)))
+                    eclim--compressed-urls-regexp "" (cl-first parts)))
          (filename-in-dir (if directory
-                (replace-regexp-in-string (concat (regexp-quote directory) "/?")
-                                          "" filename)
-              filename)))
+                              (replace-regexp-in-string
+                               (concat (regexp-quote directory) "/?")
+                               "" filename)
+                            filename)))
     (if (cdr parts)
         ;; Just put the jar path, since there's no easy way to instruct
         ;; compile-mode to go into an archive. Better than nothing.
@@ -635,21 +666,22 @@ exists, the corresponding file will be opened and the cursor
 will be moved to the location of the result."
   (let ((results
          (cl-loop for result across results
-                  for file = (cdr (assoc 'filename result))
-                  if (string-match (rx bol (or "jar" "zip") ":") file)
-                  do (setf (cdr (assoc 'filename result)) (eclim-java-archive-file file))
-                  finally (return results))))
+            for file = (cdr (assoc 'filename result))
+            if (string-match (rx bol (or "jar" "zip") ":") file)
+            do (setf (cdr (assoc 'filename result)) (eclim-java-archive-file file))
+            finally (return results))))
     (if (and (= 1 (length results)) open-single-file)
         (eclim--visit-declaration (elt results 0))
       (pop-to-buffer (get-buffer-create "*eclim: find"))
       (let ((buffer-read-only nil))
         (erase-buffer)
-        (insert (concat "-*- mode: eclim-find; default-directory: " default-directory " -*-"))
+        (insert (concat "-*- mode: eclim-find; default-directory: "
+                        default-directory " -*-"))
         (newline 2)
         (insert (concat "eclim java_search -p " pattern))
         (newline)
         (cl-loop for result across results
-                 do (insert (eclim--format-find-result result default-directory)))
+           do (insert (eclim--format-find-result result default-directory)))
         (goto-char 0)
         (grep-mode)))))
 
@@ -711,7 +743,8 @@ The delay is specified by `eclim-problems-refresh-delay'."
              eclim-autoupdate-problems)
     (setq eclim--problems-project (eclim-project-name))
     (setq eclim--problems-file buffer-file-name)
-    (run-with-idle-timer eclim-problems-refresh-delay nil (lambda () (eclim-problems-buffer-refresh)))))
+    (run-with-idle-timer eclim-problems-refresh-delay nil
+                         (lambda () (eclim-problems-buffer-refresh)))))
 
 (defun eclim-problems-buffer-refresh ()
   "Refresh the problem list and draw it on screen."
@@ -721,8 +754,10 @@ The delay is specified by `eclim-problems-refresh-delay'."
     (if (not (minibuffer-window-active-p (minibuffer-window)))
         (if (string= "e" eclim--problems-filter)
             (message "Eclim reports %d errors." (length problems))
-          (let ((warning-count (length (cl-remove-if-not (lambda (problem) (eq t (assoc-default 'warning problem)))
-                                                         problems))))
+          (let ((warning-count
+                 (length (cl-remove-if-not (lambda (problem)
+                                             (eq t (assoc-default 'warning problem)))
+                                           problems))))
             (message "Eclim reports %d errors, %d warnings."
                      (- (length problems) warning-count)
                      warning-count))))))
@@ -735,7 +770,8 @@ will apply.
 
 When a correction is selected, it will be automatically
 applied to the buffer."
-  (eclim/with-results correction-info ("java_correct" "-p" "-f" ("-l" line) ("-o" offset))
+  (eclim/with-results correction-info ("java_correct" "-p" "-f" ("-l" line)
+                                       ("-o" offset))
     (if (stringp correction-info)
         (message correction-info)
       (-if-let* ((corrections (cdr (assoc 'corrections correction-info)))
@@ -758,10 +794,12 @@ applied to the buffer."
 See `eclim--problems-filter-description' for more information."
   (if eclim--problems-filefilter
       (if eclim--problems-filter
-          (setq eclim--problems-filter-description (concat "(file-" eclim--problems-filter ")"))
+          (setq eclim--problems-filter-description
+                (concat "(file-" eclim--problems-filter ")"))
         (setq eclim--problems-filter-description "(file)"))
     (if eclim--problems-filter
-        (setq eclim--problems-filter-description (concat eclim--problems-project "(" eclim--problems-filter ")"))
+        (setq eclim--problems-filter-description
+              (concat eclim--problems-project "(" eclim--problems-filter ")"))
       (setq eclim--problems-filter-description eclim--problems-project))))
 
 (defun eclim--problems-buffer-redisplay ()
@@ -779,7 +817,7 @@ See `eclim--problems-filter-description' for more information."
             (filecol-size (eclim--problems-filecol-size)))
         (erase-buffer)
         (cl-loop for problem across (eclim--problems-filtered)
-                 do (eclim--insert-problem problem filecol-size))
+           do (eclim--insert-problem problem filecol-size))
         (goto-char (point-min))
         (forward-line (1- line-number))))))
 
@@ -792,7 +830,8 @@ names.  Otherwise, a static column width is used."
       (min 40
            (apply #'max 0
                   (mapcar (lambda (problem)
-                            (length (eclim--problems-cleanup-filename (assoc-default 'filename problem))))
+                            (length (eclim--problems-cleanup-filename
+                                     (assoc-default 'filename problem))))
                           (eclim--problems-filtered))))
     40))
 
@@ -803,7 +842,9 @@ Filtering is controlled by two variables:
 `eclim--problems-filter' and `eclim--problems-filefilter'.
 See the documentation for those variables for an explanation
 of their effects."
-  (eclim--filter-problems eclim--problems-filter eclim--problems-filefilter eclim--problems-file eclim--problems-list))
+  (eclim--filter-problems
+   eclim--problems-filter eclim--problems-filefilter
+   eclim--problems-file eclim--problems-list))
 
 (defun eclim-problems-highlight ()
   "Highlight the currently active problems in the current buffer.
@@ -817,8 +858,12 @@ Highlighting only occurs if it is allowed by
       (unless (if (functionp eclim-problems-suppress-highlights)
                   (funcall eclim-problems-suppress-highlights)
                 eclim-problems-suppress-highlights)
-        (cl-loop for problem across (cl-remove-if-not (lambda (p) (string= (assoc-default 'filename p) (file-truename (buffer-file-name)))) eclim--problems-list)
-                 do (eclim--problems-insert-highlight problem))))))
+        (cl-loop for problem across
+             (cl-remove-if-not (lambda (p)
+                                 (string= (assoc-default 'filename p)
+                                          (file-truename (buffer-file-name))))
+                               eclim--problems-list)
+           do (eclim--problems-insert-highlight problem))))))
 
 (defun eclim--insert-problem (problem filecol-size)
   "Add a problem line to the problems buffer.
@@ -841,7 +886,8 @@ FILECOL-SIZE is the width of the column reserved for displaying file names."
                       "...")
             (assoc-default 'message problem)))
          (filename (truncate-string-to-width
-                    (eclim--problems-cleanup-filename (assoc-default 'filename problem))
+                    (eclim--problems-cleanup-filename
+                     (assoc-default 'filename problem))
                     40 0 nil t))
          (text (if eclim-problems-show-pos
                    (format (concat filecol-format-string
@@ -855,7 +901,8 @@ FILECOL-SIZE is the width of the column reserved for displaying file names."
                                  " | %s")
                          filename
                          problem-message))))
-    (when (and eclim-problems-hl-errors (eq :json-false (assoc-default 'warning problem)))
+    (when (and eclim-problems-hl-errors
+               (eq :json-false (assoc-default 'warning problem)))
       (put-text-property 0 (length text) 'face 'bold text))
     (insert text)
     (insert "\n")))
@@ -911,7 +958,10 @@ match.
 PROBLEMS is the list of problems."
   (let ((type-filterp (eclim--choose-type-filter type-filter))
         (file-filterp (eclim--choose-file-filter file-filter file)))
-    (cl-remove-if-not (lambda (x) (and (funcall type-filterp x) (funcall file-filterp x))) problems)))
+    (cl-remove-if-not (lambda (x)
+                        (and (funcall type-filterp x)
+                             (funcall file-filterp x)))
+                      problems)))
 
 (defun eclim--problem-goto-pos (p)
   "Move the cursor in the current buffer to position P.

--- a/eclim-completion.el
+++ b/eclim-completion.el
@@ -30,6 +30,8 @@
 ;; company-emacs-eclim.el -- completion functions used by the company-mode
 ;;    and auto-complete-mode backends.
 ;;
+;;
+;;; Code:
 
 (require 'thingatpt)
 (require 'cl-lib)
@@ -59,11 +61,13 @@ which removes all arguments before inserting.")
             (cl-case major-mode
               (java-mode
                (assoc-default 'completions
-                              (eclim/execute-command "java_complete" "-p" "-f" "-e" ("-l" "standard") "-o")))
+                              (eclim/execute-command "java_complete" "-p" "-f"
+                                                     "-e" ("-l" "standard") "-o")))
               ((xml-mode nxml-mode)
                (eclim/execute-command "xml_complete" "-p" "-f" "-e" "-o"))
               (groovy-mode
-               (eclim/execute-command "groovy_complete" "-p" "-f" "-e" ("-l" "standard") "-o"))
+               (eclim/execute-command "groovy_complete" "-p" "-f" "-e"
+                                      ("-l" "standard") "-o"))
               (ruby-mode
                (eclim/execute-command "ruby_complete" "-p" "-f" "-e" "-o"))
               (php-mode
@@ -71,9 +75,11 @@ which removes all arguments before inserting.")
               ((javascript-mode js-mode)
                (eclim/execute-command "javascript_complete" "-p" "-f" "-e" "-o"))
               (scala-mode
-               (eclim/execute-command "scala_complete" "-p" "-f" "-e" ("-l" "standard") "-o"))
+               (eclim/execute-command "scala_complete" "-p" "-f" "-e"
+                                      ("-l" "standard") "-o"))
               ((c++-mode c-mode)
-               (eclim/execute-command "c_complete" "-p" "-f" "-e" ("-l" "standard") "-o"))
+               (eclim/execute-command "c_complete" "-p" "-f" "-e"
+                                      ("-l" "standard") "-o"))
               (python-mode
                (eclim/execute-command "python_complete" "-p" "-f" "-e" "-o"))))
     (setq eclim--is-completing nil)))
@@ -179,7 +185,8 @@ The result is also stored in `eclim--completion-start'."
   (setq eclim--completion-start
         (save-excursion
           (cl-case major-mode
-            ((java-mode javascript-mode js-mode ruby-mode groovy-mode php-mode c-mode c++-mode scala-mode python-mode)
+            ((java-mode javascript-mode js-mode ruby-mode groovy-mode
+                        php-mode c-mode c++-mode scala-mode python-mode)
              (progn
                ;; Allow completion after open bracket. Eclipse/eclim do.
                (when (or (eq ?\( (char-before))
@@ -196,7 +203,8 @@ The result is also stored in `eclim--completion-start'."
                  (forward-char 1))
                (point)))
             ((xml-mode nxml-mode)
-             (while (not (string-match "[<\n[:blank:]]" (char-to-string (char-before))))
+             (while (not (string-match "[<\n[:blank:]]"
+                                       (char-to-string (char-before))))
                (backward-char))
              (point))))))
 
@@ -206,13 +214,16 @@ BEG and END are the integer positions within the current
 buffer marking the region which is replaced."
   (let ((completion (buffer-substring-no-properties beg end)))
     (cond ((string-match "\\(.*?\\) :.*- Override method" completion)
-           (let ((sig (eclim--java-parse-method-signature (match-string 1 completion))))
+           (let ((sig (eclim--java-parse-method-signature
+                       (match-string 1 completion))))
              (delete-region beg end)
              (eclim-java-implement (symbol-name (assoc-default :name sig)))))
           ((string-match "\\([^-:]+\\) .*?\\(- *\\(.*\\)\\)?" completion)
            (let* ((insertion (match-string 1 completion))
                   (rest (match-string 3 completion))
-                  (package (if (and rest (string-match "\\w+\\(\\.\\w+\\)*" rest)) rest nil))
+                  (package (if (and rest
+                                    (string-match "\\w+\\(\\.\\w+\\)*" rest))
+                               rest nil))
                   (template (eclim--completion-yasnippet-convert insertion)))
              (delete-region beg end)
              (unless (cl-loop for f in eclim-insertion-functions thereis
@@ -223,21 +234,26 @@ buffer marking the region which is replaced."
                (insert insertion)))
              (when package
                (eclim-java-import
-                (concat package "." (substring insertion 0 (or (string-match "[<(]" insertion)
-                                                               (length insertion)))))))))))
+                (concat package "."
+                        (substring insertion 0
+                                   (or (string-match "[<(]" insertion)
+                                       (length insertion)))))))))))
 
 (defun eclim--completion-action-xml (beg end)
   "Perform an XML-style completion.
 BEG and END are the integer positions within the current
 buffer marking the region which is replaced."
   (when (string-match "[\n[:blank:]]" (char-to-string (char-before beg)))
-    ;; we are completing an attribute; let's use yasnippet to get som nice completion going
+    ;; we are completing an attribute; let's use yasnippet to get som nice
+    ;; completion going
     (let* ((c (buffer-substring-no-properties beg end))
            (completion (if (s-ends-with? "\"" c) c (concat c "=\"\""))))
       (when (string-match "\\(.*\\)=\"\\(.*\\)\"" completion)
         (delete-region beg end)
         (if (and eclim-use-yasnippet (featurep 'yasnippet)  yas-minor-mode)
-            (yas-expand-snippet (format "%s=\"${1:%s}\" $0" (match-string 1 completion) (match-string 2 completion)))
+            (yas-expand-snippet
+             (format "%s=\"${1:%s}\" $0"
+                     (match-string 1 completion) (match-string 2 completion)))
           (insert completion))))))
 
 (defun eclim--completion-action-default ()
@@ -272,17 +288,22 @@ buffer marking the region which is replaced."
 The rendering is rather rudimentary."
   (apply #'concat
          (cl-loop for p = 0 then (match-end 0)
-                  while (string-match "[[:blank:]]*\\(.*?\\)\\(</?.*?>\\)" str p) collect (match-string 1 str) into ret
-                  for tag = (downcase (match-string 2 str))
-                  when (or (string= tag "</p>") (string= tag "<p>")) collect "\n" into ret
-                  when (string= tag "<br/>") collect " " into ret
-                  when (string= tag "<li>") collect " * " into ret
-                  finally return (append ret (list (substring str p))))))
+            while (string-match "[[:blank:]]*\\(.*?\\)\\(</?.*?>\\)" str p)
+            collect (match-string 1 str) into ret
+            for tag = (downcase (match-string 2 str))
+            when (or (string= tag "</p>") (string= tag "<p>")) collect "\n" into ret
+            when (string= tag "<br/>") collect " " into ret
+            when (string= tag "<li>") collect " * " into ret
+            finally return (append ret (list (substring str p))))))
 
 (defun eclim--completion-documentation (symbol)
   "Look up the documentation string for the given SYMBOL.
 SYMBOL is looked up in `eclim--completion-condidates'."
-  (let ((doc (assoc-default 'info (cl-find symbol eclim--completion-candidates :test #'string= :key #'eclim--completion-candidate-menu-item))))
+  (let ((doc
+         (assoc-default
+          'info (cl-find symbol eclim--completion-candidates
+                         :test #'string=
+                         :key #'eclim--completion-candidate-menu-item))))
     (when doc
       (eclim--render-doc doc))))
 
@@ -299,3 +320,4 @@ if the argument list is empty.  Meant for use with
   t)
 
 (provide 'eclim-completion)
+;;; eclim-completion.el ends here

--- a/eclim-debug.el
+++ b/eclim-debug.el
@@ -19,7 +19,6 @@
 ;;
 ;;; Contributors
 ;;
-;;
 ;;; Commentary:
 ;;
 ;;; Conventions
@@ -32,6 +31,7 @@
 ;; eclim-debug.el -- emacs-eclim integration with gud and jdb to
 ;; support debugging
 ;;
+;;; Code:
 
 (require 'eclim-project)
 (require 'eclim-java)
@@ -51,7 +51,8 @@
                   (debug . t)
                   (main-class . ,main-class)
                   (program-args . ,args)
-                  (vm-args . ,(concat "-sourcepath" (eclim-java-run-sourcepath project)))))
+                  (vm-args . ,(concat "-sourcepath"
+                                      (eclim-java-run-sourcepath project)))))
         (classpath (eclim/java-classpath project)))
     (eclim-java-run--command config (eclim-java-run--java-vm-args classpath))))
 
@@ -70,7 +71,8 @@
 
 (defun eclim--debug-maven-run ()
   (concat "mvn -f " (eclim--maven-pom-path)
-          "clean test -Dmaven.surefire.debug -Dtest=" (file-name-base)))
+          "clean test -Dmaven.surefire.debug -Dtest="
+          (file-name-base (buffer-file-name))))
 
 (defun eclim--debug-project-maven? ()
   (eclim--debug-file-exists-in-project-root? "pom.xml"))
@@ -96,6 +98,7 @@
                 (lambda (txt) (eclim--debug-attach-when-ready txt project port))))))
 
 (defun eclim-debug-junit ()
+  "Debug Junit test."
   (interactive)
   (let ((project (eclim-project-name))
         (classes (eclim-package-and-class)))
@@ -103,18 +106,22 @@
      (eclim--debug-jdb-run-command project "org.junit.runner.JUnitCore" classes))))
 
 (defun eclim-debug-maven-test ()
+  "Debug maven test."
   (interactive)
   (eclim--debug-run-process-and-attach (eclim--debug-maven-run) 5005))
 
 (defun eclim-debug-ant-test ()
+  "Debug ant test."
   (interactive)
   (eclim--debug-run-process-and-attach (eclim--debug-ant-run) 5005))
 
 (defun eclim-debug-attach (port project)
+  "Attach debugger for PROJECT to PORT."
   (interactive (list (read-number "Port: " 5005) (eclim-project-name)))
   (eclim-debug/jdb (eclim--debug-jdb-attach-command project port)))
 
 (defun eclim-debug-test ()
+  "Debug test based on availability."
   (interactive)
   (cond ((eclim-java-junit-buffer?) (eclim-debug-junit))
         ((eclim--debug-project-maven?) (eclim-debug-maven-test))
@@ -122,3 +129,4 @@
         (t (message "I can't debug this. I wasn't program smart enough. Please help me"))))
 
 (provide 'eclim-debug)
+;;; eclim-debug.el ends here

--- a/eclim-java-run.el
+++ b/eclim-java-run.el
@@ -19,7 +19,6 @@
 ;;
 ;;; Contributors
 ;;
-;;
 ;;; Commentary:
 ;;
 ;;; Conventions
@@ -31,6 +30,7 @@
 ;;
 ;; eclim-java-run.el -- java run configurations for eclim
 ;;
+;;; Code:
 
 (require' eclim-project)
 (require 'eclim-java)
@@ -49,15 +49,15 @@
 
 (defun eclim-java-run--project-sourcepath (project)
   (eclim-java-run--read-sourcepath
-   (concat (eclim-java-run--project-dir project)
-           ".classpath")))
+   (concat (eclim-java-run--project-dir project) ".classpath")))
 
 (defun eclim-java-run--read-sourcepath (classpath-file)
   (let* ((root (car (xml-parse-file classpath-file)))
          (classpathentries (xml-get-children root 'classpathentry))
          (srcs (-filter 'eclim-java-run--src?? classpathentries))
          (paths-relative (-map 'eclim-java-run--get-path srcs))
-         (paths-absolute (--map (concat (file-name-directory classpath-file) it) paths-relative)))
+         (paths-absolute (--map (concat (file-name-directory classpath-file) it)
+                                paths-relative)))
     paths-absolute))
 
 (defun eclim-java-run--src?? (classpathentry)
@@ -76,8 +76,10 @@
     (buffer-string)))
 
 (defun eclim-java-run--load-configurations (project)
-  (let* ((configurations-path (concat (eclim-java-run--project-dir project) ".eclim"))
-         (configurations (read (eclim-java-run--get-string-from-file configurations-path))))
+  (let* ((configurations-path
+          (concat (eclim-java-run--project-dir project) ".eclim"))
+         (configurations
+          (read (eclim-java-run--get-string-from-file configurations-path))))
     configurations))
 
 (defun eclim-java-run--get-value (key alist)
@@ -108,21 +110,24 @@
                 (eclim-java-run--get-value 'program-args config)))))
 
 (defun eclim-java-run--run-jdb (config classpath sourcepath project-dir)
-  (let* ((command (eclim-java-run--command config
-                                           (eclim-java-run--debug-vm-args classpath sourcepath))))
+  (let* ((command (eclim-java-run--command
+                   config
+                   (eclim-java-run--debug-vm-args classpath sourcepath))))
     (with-temp-buffer
       (setq default-directory project-dir)
       (eclim-debug/jdb command))))
 
 (defun eclim-java-run--run-java (config classpath project-dir)
   (let* ((name (eclim-java-run--get-value 'name config))
-         (command (eclim-java-run--command config (eclim-java-run--java-vm-args classpath)))
+         (command (eclim-java-run--command
+                   config (eclim-java-run--java-vm-args classpath)))
          (new-buffer-name (concat "*" name "*")))
     (when (buffer-live-p (get-buffer new-buffer-name)) (kill-buffer new-buffer-name))
     (with-temp-buffer
       (setq default-directory project-dir)
-      (switch-to-buffer (process-buffer
-                         (start-process-shell-command name new-buffer-name command))))))
+      (switch-to-buffer
+       (process-buffer
+        (start-process-shell-command name new-buffer-name command))))))
 
 (defun eclim-java-run--configuration (name confs)
   (car
@@ -135,9 +140,12 @@
                    nil t))
 
 (defun eclim-java-run-run (configuration-name)
+  "Run current project using configurations from CONFIGURATION-NAME."
   (interactive (list (eclim-java-run--ask-which-configuration)))
-  (let* ((configurations (eclim-java-run--load-configurations (eclim-project-name)))
-         (configuration (eclim-java-run--configuration configuration-name configurations))
+  (let* ((configurations
+          (eclim-java-run--load-configurations (eclim-project-name)))
+         (configuration
+          (eclim-java-run--configuration configuration-name configurations))
          (project-dir (eclim-java-run--project-dir (eclim-project-name)))
          (classpath (eclim/java-classpath (eclim-project-name)))
          (debug? (eclim-java-run--jdb? configuration)))
@@ -151,15 +159,18 @@
                                 project-dir))))
 
 (defun eclim-run-configuration (configuration-name)
-      "Runs the configuration given in CONFIGURATION-NAME in the compilation buffer."
-      (interactive (list (eclim-java-run--ask-which-configuration)))
-      (let* ((configurations (eclim-java-run--load-configurations (eclim-project-name)))
-             (configuration (eclim-java-run--configuration configuration-name configurations))
-             (project-dir (eclim-java-run--project-dir (eclim-project-name)))
-             (classpath (eclim/java-classpath (eclim-project-name)))
-             (default-directory project-dir)
-             (command (eclim-java-run--command configuration (eclim-java-run--java-vm-args classpath))))
-        (compile command)))
+  "Runs the configuration given in CONFIGURATION-NAME in the compilation buffer."
+  (interactive (list (eclim-java-run--ask-which-configuration)))
+  (let* ((configurations
+          (eclim-java-run--load-configurations (eclim-project-name)))
+         (configuration
+          (eclim-java-run--configuration configuration-name configurations))
+         (project-dir (eclim-java-run--project-dir (eclim-project-name)))
+         (classpath (eclim/java-classpath (eclim-project-name)))
+         (default-directory project-dir)
+         (command (eclim-java-run--command
+                   configuration (eclim-java-run--java-vm-args classpath))))
+    (compile command)))
 
 (provide 'eclim-java-run)
 ;;; eclim-java-run.el ends here

--- a/eclim-java.el
+++ b/eclim-java.el
@@ -19,7 +19,6 @@
 ;;
 ;; - Tassilo Horn <tassilo@member.fsf.org>
 ;;
-;;
 ;;; Commentary:
 ;;
 ;;; Conventions
@@ -27,6 +26,8 @@
 ;; Conventions used in this file: Name internal variables and functions
 ;; "eclim--<descriptive-name>", and name eclim command invocations
 ;; "eclim/command-name", like eclim/project-list.
+;;
+;;; Code:
 
 ;;* Eclim Java
 
@@ -67,9 +68,9 @@
   :group 'eclim)
 
 (defcustom eclim-java-major-modes '(java-mode jde-mode)
-  "This variable contains a list of major modes to edit java
-files. There are certain operations, that eclim will only perform when
-the current buffer is contained within this list"
+  "This variable contains a list of major modes to edit java files.
+There are certain operations, that eclim will only perform when
+the current buffer is contained within this list."
   :group 'eclim-java
   :type 'list)
 
@@ -77,8 +78,8 @@ the current buffer is contained within this list"
 (defcustom eclim-java-documentation-root nil
   "Root directory of Java HTML documentation.
 
-If Android is used then Eclipse may refer standard Java elements from the copy of
-Java documentation under Android docs, so don't forget to set
+If Android is used then Eclipse may refer standard Java elements from the copy
+of Java documentation under Android docs, so don't forget to set
 `eclim-java-android-documentation-root' too in that case."
   :group 'eclim-java
   :type 'directory)
@@ -120,26 +121,32 @@ Java documentation under Android docs, so don't forget to set
 See `eclim-run-class'.")
 
 (defun eclim/groovy-src-update (&optional save-others)
-  "If `eclim-auto-save' is non-nil, save the current java
- buffer. In addition, if `save-others' is non-nil, also save any
- other unsaved buffer. Finally, tell eclim to update its java
+  "If `eclim-auto-save' is non-nil, save the current java buffer.
+In addition, if `SAVE-OTHERS' is non-nil, also save any
+other unsaved buffer.  Finally, tell eclim to update its java
  sources."
   (when eclim-auto-save
-    (when (buffer-modified-p) (save-buffer)) ;; auto-save current buffer, prompt on saving others
-    (when save-others (save-some-buffers nil (lambda () (string-match "\\.groovy$" (buffer-file-name)))))))
+    ;; auto-save current buffer, prompt on saving others
+    (when (buffer-modified-p) (save-buffer))
+    (when save-others
+      (save-some-buffers
+       nil (lambda () (string-match "\\.groovy$" (buffer-file-name)))))))
 
 (defun eclim/java-src-update (&optional save-others)
-  "If `eclim-auto-save' is non-nil, save the current java
-buffer. In addition, if `save-others' is non-nil, also save any
-other unsaved buffer. Finally, tell eclim to update its java
-sources."
+  "If `eclim-auto-save' is non-nil, save the current java buffer.
+In addition, if SAVE-OTHERS is non-nil, also save any other unsaved buffer.
+ Finally, tell eclim to update its java sources."
   (when eclim-auto-save
-    (when (buffer-modified-p) (save-buffer)) ;; auto-save current buffer, prompt on saving others
-    (when save-others (save-some-buffers nil (lambda () (string-match "\\.java$" (buffer-file-name)))))))
+    ;; auto-save current buffer, prompt on saving others
+    (when (buffer-modified-p) (save-buffer))
+    (when save-others
+      (save-some-buffers
+       nil (lambda () (string-match "\\.java$" (buffer-file-name)))))))
 
+;; This is used to advise the `delete-file' (ORIG-FUNCTION) function to trigger
+;; a source update in eclim when appropriate. This advice is added when
+;; eclim-mode is started and removed on exit.
 (defun eclim-java-delete-file (orig-function filename &optional trash)
-  "Advice the `delete-file' function to trigger a source update
-in eclim when appropriate."
   (let ((pr nil)
         (fn nil))
     (ignore-errors
@@ -147,7 +154,8 @@ in eclim when appropriate."
            (setq fn (file-relative-name filename (eclim--project-dir pr)))))
     (funcall orig-function filename trash)
     (when (and pr fn)
-      (ignore-errors (apply 'eclim--call-process (list "java_src_update" "-p" pr "-f" fn))))))
+      (ignore-errors (apply 'eclim--call-process
+                            (list "java_src_update" "-p" pr "-f" fn))))))
 
 (defun eclim--java-parser-read (str)
   (cl-first
@@ -163,33 +171,37 @@ in eclim when appropriate."
 
 (defun eclim--java-parse-method-signature (signature)
   (cl-flet ((parser3/parse-arg (arg)
-                               (let ((arg-rev (reverse arg)))
-                                 (cond ((null arg) nil)
-                                       ((= (length arg) 1) (list (list :type (cl-first arg))))
-                                       ((listp (cl-first arg-rev)) (list (cons :type arg)))
-                                       (t (list (cons :name (cl-first arg-rev)) (cons :type (reverse (cl-rest arg-rev)))))))))
+              (let ((arg-rev (reverse arg)))
+                (cond ((null arg) nil)
+                      ((= (length arg) 1) (list (list :type (cl-first arg))))
+                      ((listp (cl-first arg-rev)) (list (cons :type arg)))
+                      (t (list (cons :name (cl-first arg-rev))
+                               (cons :type (reverse (cl-rest arg-rev)))))))))
     (let ((ast (reverse (eclim--java-parser-read signature))))
       (list (cons :arglist (mapcar #'parser3/parse-arg (cl-first ast)))
             (cons :name (cl-second ast))
             (cons :return (reverse (cl-rest (cl-rest ast))))))))
 
 (defun eclim--java-current-type-name (&optional type)
-  "Searches backward in the current buffer until a type
-declaration has been found. TYPE may be either 'class',
-'interface', 'enum' or nil, meaning 'match all of the above'."
+  "Search backward in the current buffer until a type declaration has been \
+found.  TYPE may be either 'class', 'interface', 'enum' or nil, meaning 'match
+all of the above'."
   (save-excursion
     (if (re-search-backward
-         (concat (or type "\\(class\\|interface\\|enum\\)") "\\s-+\\([^<{\s-]+\\)") nil t)
+         (concat (or type "\\(class\\|interface\\|enum\\)") "\\s-+\\([^<{\s-]+\\)")
+         nil 'move)
         (match-string-no-properties 2)
       "")))
 
 (defun eclim--java-current-class-name ()
-  "Searches backward in the current buffer until a class declaration
-has been found."
+  "Search backwards in the current buffer until a class declaration has been \
+found."
   (eclim--java-current-type-name "\\(class\\)"))
 
 (defun eclim--java-generate-bean-properties (project file offset encoding type)
-  "Generates a bean property for the symbol at point. TYPE specifies the property to generate."
+  "Generate a bean property for the symbol at point.
+TYPE specifies the property to generate in PROJECT's FILE at OFFSET with
+ENCODING."
   (eclim--call-process "java_bean_properties"
                        "-p" project
                        "-f" file
@@ -200,20 +212,23 @@ has been found."
   (revert-buffer t t t))
 
 (defun eclim--java-refactor (result)
-  "Processes the resulst of a refactor command. RESULT is the
-  results of invoking eclim/execute-command."
+  "Processes the resulst of a refactor command.
+RESULT is the results of invoking eclim/execute-command."
   (if (stringp result) (error "%s" result))
-  (cl-loop for (from to) in (mapcar (lambda (x) (list (assoc-default 'from x) (assoc-default 'to x))) result)
-           do (when (and from to)
-                (kill-buffer (find-buffer-visiting from))
-                (find-file to)))
+  (cl-loop for (from to) in (mapcar
+                             (lambda (x)
+                               (list (assoc-default 'from x) (assoc-default 'to x)))
+                             result)
+     do (when (and from to)
+          (kill-buffer (find-buffer-visiting from))
+          (find-file to)))
   (save-excursion
     (cl-loop for file in (mapcar (lambda (x) (assoc-default 'file x)) result)
-             do (when file
-                  (let ((buf (get-file-buffer (file-name-nondirectory file))))
-                    (when buf
-                      (switch-to-buffer buf)
-                      (revert-buffer t t t))))))
+       do (when file
+            (let ((buf (get-file-buffer (file-name-nondirectory file))))
+              (when buf
+                (switch-to-buffer buf)
+                (revert-buffer t t t))))))
   (message "Done"))
 
 (defun eclim/java-classpath (project)
@@ -223,7 +238,8 @@ has been found."
 (defun eclim/java-classpath-variables ()
   ;; TODO: fix trailing whitespaces
   (mapcar (lambda (line)
-            (split-string line "-")) (eclim--call-process "java_classpath_variables")))
+            (split-string line "-"))
+          (eclim--call-process "java_classpath_variables")))
 
 (defun eclim/java-classpath-variable-create (name path)
   (eclim--call-process "java_classpath_variable_create" "-n" name "-p" path))
@@ -232,7 +248,7 @@ has been found."
   (eclim--call-process "java_classpath_variable_create" "-n" name))
 
 (defun eclim-java-doc-comment ()
-  "Inserts or updates a javadoc comment for the element at point."
+  "Insert or update a javadoc comment for the element at point."
   (interactive)
   (eclim/execute-command "javadoc_comment" "-p" "-f" "-o"))
 
@@ -240,19 +256,23 @@ has been found."
   "Run Javadoc on current or all projects."
   (interactive)
   (let ((proj-list (eclim/project-list)))
-    (if (y-or-n-p "Run Javadoc for all projects?")
+    (if (y-or-n-p "Run Javadoc for all projects? ")
         (dotimes (i (length proj-list))
-            (eclim--call-process-no-parse "javadoc" "-p" (cl-rest (assq 'name (elt proj-list i)))))
+          (eclim--call-process-no-parse "javadoc" "-p"
+                                        (cl-rest (assq 'name (elt proj-list i)))))
       (eclim--call-process-no-parse "javadoc" "-p"))
     (message "Javadoc creation finished.")))
 
 (defun eclim-java-format ()
   "Format the source code of the current java source file."
   (interactive)
-  (eclim/execute-command "java_format" "-p" "-f" ("-h" 0) ("-t" (1- (point-max))) "-e"))
+  (eclim/execute-command
+   "java_format" "-p" "-f" ("-h" 0) ("-t" (1- (point-max))) "-e"))
 
 (defun eclim-java-generate-getter-and-setter (project file offset encoding)
-  "Generates getter and setter methods for the symbol at point."
+  "Generate getter and setter methods for the symbol at point when called \
+interactively.
+Methods are generated in the PROJECT's FILE at OFFSET with ENCODING."
   (interactive (list (eclim-project-name)
                      (eclim--project-current-file)
                      (eclim--byte-offset)
@@ -260,7 +280,8 @@ has been found."
   (eclim--java-generate-bean-properties project file offset encoding "gettersetter"))
 
 (defun eclim-java-generate-getter (project file offset encoding)
-  "Generates a getter method for the symbol at point."
+  "Generate a getter method for the symbol at point.
+Methods are generated in the PROJECT's FILE at OFFSET with ENCODING."
   (interactive (list (eclim-project-name)
                      (eclim--project-current-file)
                      (eclim--byte-offset)
@@ -268,7 +289,8 @@ has been found."
   (eclim--java-generate-bean-properties project file offset encoding "getter"))
 
 (defun eclim-java-generate-setter (project file offset encoding)
-  "Generates a setter method for the symbol at point."
+  "Generate a setter method for the symbol at point.
+Methods are generated in the PROJECT's FILE at OFFSET with ENCODING."
   (interactive (list (eclim-project-name)
                      (eclim--project-current-file)
                      (eclim--byte-offset)
@@ -276,9 +298,11 @@ has been found."
   (eclim--java-generate-bean-properties project file offset encoding "setter"))
 
 (defun eclim-java-constructor ()
+  "Generate a constructor from the selected fields."
   (interactive)
   (let ((fields (eclim--java-get-selected-fields)))
-    (eclim/execute-command "java_constructor" "-p" "-f" "-o" (when fields (list "-r" (json-encode fields))))))
+    (eclim/execute-command "java_constructor" "-p" "-f" "-o"
+                           (when fields (list "-r" (json-encode fields))))))
 
 (defun eclim--java-get-selected-fields ()
   "Return the names of the fields in the current selection."
@@ -290,21 +314,29 @@ has been found."
       ;; Remove all single line comments,
       (setf region (replace-regexp-in-string "//.*" "" region))
       ;; Remove all double quoted strings, accounting for escaped quotes.
-      (setf region (replace-regexp-in-string "\"\\(?:[^\"\\\\]\\|\\\\.\\)*?\"" "" region))
+      (setf region (replace-regexp-in-string "\"\\(?:[^\"\\\\]\\|\\\\.\\)*?\"" ""
+                                             region))
       ;; Remove all single quoted characters, accounting for escaped quotes.
-      (setf region (replace-regexp-in-string "'\\(?:[^'\\\\]\\|\\\\.\\)*?'" "" region))
-      ;; Now that string and char literals are gone, we can freely match special characters.
+      (setf region (replace-regexp-in-string "'\\(?:[^'\\\\]\\|\\\\.\\)*?'" ""
+                                             region))
+      ;; Now that string and char literals are gone, we can freely match special
+      ;; characters.
       ;; Split fields onto their own lines, ensuring each is ended with a semicolon.
       (setf region (replace-regexp-in-string "\\(?:,\\|;\\)[^\n]?" ";\n" region))
       ;; Remove trailing whitespace.
       (setf region (replace-regexp-in-string "\\s-*$" "" region))
-      ;; Remove the assignment portions, any whitespace between the field and the semicolon, and any whitespace after the semicolon.
-      (setf region (replace-regexp-in-string "\\s-*\\(?:=[^;]*\\)?;\\s-*$" ";" region))
-      ;; Remove any line which does not end with a semicolon, since it is not a (complete) field declaration.
+      ;; Remove the assignment portions, any whitespace between the field and
+      ;; the semicolon, and any whitespace after the semicolon.
+      (setf region (replace-regexp-in-string "\\s-*\\(?:=[^;]*\\)?;\\s-*$" ";"
+                                             region))
+      ;; Remove any line which does not end with a semicolon, since it is not a
+      ;; (complete) field declaration.
       (setf region (replace-regexp-in-string "^[^\n]*[^;\n]$" "" region))
-      ;; Each line is now an identifier (field name) followed by a semicolon, with possible whitespace. Extract the field name.
+      ;; Each line is now an identifier (field name) followed by a semicolon,
+      ;; with possible whitespace. Extract the field name.
       (setf region (replace-regexp-in-string "^.*?\\(\\S-*\\)\\s-*;$" "\\1" region))
-      ;; Split into lines, trimming whitespace and removing empty lines. This leaves only the field names.
+      ;; Split into lines, trimming whitespace and removing empty lines. This
+      ;; leaves only the field names.
       (split-string region "\n" t "\\s-*"))))
 
 (defun eclim/java-call-hierarchy (project file offset length encoding)
@@ -323,7 +355,7 @@ has been found."
                        "-e" encoding))
 
 (defun eclim/java-src-dirs (project)
-  "Queries Eclimd for the list of source directories in the project."
+  "Queries Eclimd for the list of source directories in the PROJECT."
   (split-string (eclim--call-process "java_src_dirs" "-p" project) "\n"))
 
 (defun eclim-java-refactor-rename-symbol-at-point ()
@@ -336,8 +368,9 @@ has been found."
       (eclim--java-refactor res))))
 
 (defun eclim-java-refactor-move-class ()
-  "Renames the java class. Searches backward in the current buffer
-until a class declaration has been found."
+  "Renames the java class.
+Searches backward in the current buffer until a
+class declaration has been found."
   (interactive)
   (let* ((class-name (eclim--java-current-class-name))
          (package-name (eclim--java-current-package))
@@ -346,6 +379,7 @@ until a class declaration has been found."
       (eclim--java-refactor res))))
 
 (defun eclim-java-call-hierarchy (project file encoding)
+  "Displays the call hierarchy for FILE in PROJECT with ENCODING."
   (interactive (list (eclim-project-name)
                      (eclim--project-current-file)
                      (eclim--current-encoding)))
@@ -353,8 +387,9 @@ until a class declaration has been found."
     (save-excursion
       (if (re-search-backward boundary nil t)
           (forward-char))
-      (let ((top-node (eclim/java-call-hierarchy project file (eclim--byte-offset)
-                                                 (length (cdr (eclim--java-identifier-at-point t))) encoding)))
+      (let ((top-node (eclim/java-call-hierarchy
+                       project file (eclim--byte-offset)
+                       (length (cdr (eclim--java-identifier-at-point t))) encoding)))
         (pop-to-buffer "*eclim: call hierarchy*" t)
         (special-mode)
         (let ((buffer-read-only nil))
@@ -363,6 +398,7 @@ until a class declaration has been found."
            project
            top-node
            0))))))
+
 (defun eclim--java-insert-call-hierarchy-node (project node level)
   (let ((declaration (cdr (assoc 'name node))))
     (insert (format (concat "%-"(number-to-string (* level 2)) "s=> ") ""))
@@ -376,9 +412,10 @@ until a class declaration has been found."
         (insert declaration)))
     (newline)
     (cl-loop for caller across (cdr (assoc 'callers node))
-             do (eclim--java-insert-call-hierarchy-node project caller (1+ level)))))
+       do (eclim--java-insert-call-hierarchy-node project caller (1+ level)))))
 
 (defun eclim-java-hierarchy (project file offset encoding)
+  "Displays the call hierarchy for the element at OFFSET in FILE in PROJECT with ENCODING."
   (interactive (list (eclim-project-name)
                      (eclim--project-current-file)
                      (eclim--byte-offset)
@@ -394,7 +431,9 @@ until a class declaration has been found."
        0))))
 
 (defun eclim--java-insert-file-path-for-hierarchy-node (node)
-  (eclim/with-results hits ("java_search" ("-p" (cdr (assoc 'qualified node))) ("-t" "type") ("-x" "declarations") ("-s" "workspace"))
+  (eclim/with-results hits
+    ("java_search" ("-p" (cdr (assoc 'qualified node)))
+     ("-t" "type") ("-x" "declarations") ("-s" "workspace"))
     (assoc-default 'filename (elt hits 0))))
 
 (defun eclim--java-insert-hierarchy-node (project node level)
@@ -412,92 +451,101 @@ until a class declaration has been found."
   (newline)
   (let ((children (cdr (assoc 'children node))))
     (cl-loop for child across children do
-             (eclim--java-insert-hierarchy-node project child (+ level 1)))))
+         (eclim--java-insert-hierarchy-node project child (+ level 1)))))
 
 (defun eclim-java-find-declaration ()
   "Find and display the declaration of the java identifier at point."
   (interactive)
   (let ((i (eclim--java-identifier-at-point t)))
-    (eclim/with-results hits ("java_search" "-n" "-f" ("-o" (car i)) ("-l" (length (cdr i))) ("-x" "declaration"))
+    (eclim/with-results hits
+      ("java_search" "-n" "-f" ("-o" (car i))
+       ("-l" (length (cdr i))) ("-x" "declaration"))
       (eclim--find-display-results (cdr i) hits t))))
 
 (defun eclim-c-find-declaration ()
   "Find and display the declaration of the c identifier at point."
   (interactive)
   (let ((i (eclim--java-identifier-at-point t)))
-    (eclim/with-results hits ("c_search" "-n" "-f" ("-o" (car i)) ("-l" (length (cdr i))))
+    (eclim/with-results hits ("c_search" "-n" "-f" ("-o" (car i))
+                              ("-l" (length (cdr i))))
       (eclim--find-display-results (cdr i) hits t))))
 
 (defun eclim-java-find-references ()
   "Find and display references for the java identifier at point."
   (interactive)
   (let ((i (eclim--java-identifier-at-point t)))
-    (eclim/with-results hits ("java_search" "-n" "-f" ("-o" (car i)) ("-l" (length (cdr i))) ("-x" "references"))
+    (eclim/with-results hits ("java_search" "-n" "-f" ("-o" (car i))
+                              ("-l" (length (cdr i))) ("-x" "references"))
       (eclim--find-display-results (cdr i) hits))))
 
 (defun eclim-java-find-type (type-name &optional case-insensitive)
-  "Searches the project for a given class. The TYPE-NAME is the
-pattern, which will be used for the search. If invoked with the
-universal argument the search will be made CASE-INSENSITIVE."
-  (interactive (list (read-string "Name: " (let ((case-fold-search nil)
-                                                 (current-symbol (symbol-name (symbol-at-point))))
-                                             (if (string-match-p "^[A-Z]" current-symbol)
-                                                 current-symbol
-                                               (eclim--java-current-type-name))))
-                     "P"))
-  (eclim-java-find-generic "workspace" "declarations" "type" type-name case-insensitive t))
+  "Search the project for a given class.
+The TYPE-NAME is the pattern, which will be used for the search.
+If invoked with the universal argument the search will be made
+CASE-INSENSITIVE."
+  (interactive
+   (list (read-string "Name: "
+                      (let ((case-fold-search nil)
+                            (current-symbol (symbol-name (symbol-at-point))))
+                        (if (string-match-p "^[A-Z]" current-symbol)
+                            current-symbol
+                          (eclim--java-current-type-name))))
+         "P"))
+  (eclim-java-find-generic "workspace" "declarations" "type"
+                           type-name case-insensitive t))
 
-(defun eclim-java-find-generic (scope context type pattern &optional case-insensitive open-single-file)
-  "Searches within SCOPE (all/project/type) for a
-TYPE (all/annotation/class/classOrEnum/classOrInterface/constructor/enum/field/interface/method/package/type)
-matching the given
-CONTEXT (all/declarations/implementors/references) and
-PATTERN. If invoked with the universal argument the search will
-be made CASE-INSENSITIVE."
+(defun eclim-java-find-generic (scope context type pattern
+                                      &optional case-insensitive open-single-file)
+  "Search within SCOPE (all/project/type) for a TYPE \
+\(all/annotation/class/classOrEnum/classOrInterface/constructor/enum \
+/field/interface/method/package/type) matching the given CONTEXT \
+\(all/declarations/implementors/references) and PATTERN.
+If invoked with the universal argument the search will be made CASE-INSENSITIVE.
+OPEN-SINGLE-FILE is passed to `eclim--java-package-components'."
   (interactive (list (eclim--completing-read "Scope: " eclim--java-search-scopes)
                      (eclim--completing-read "Context: " eclim--java-search-contexts)
                      (eclim--completing-read "Type: " eclim--java-search-types)
                      (read-string "Pattern: ")
                      "P"))
-  (eclim/with-results hits ("java_search" ("-p" pattern) ("-t" type) ("-x" context) ("-s" scope) (if case-insensitive '("-i" "")))
+  (eclim/with-results hits ("java_search" ("-p" pattern) ("-t" type)
+                            ("-x" context) ("-s" scope)
+                            (if case-insensitive '("-i" "")))
     (eclim--find-display-results pattern hits open-single-file)))
 
 (defun eclim--java-package-components (package)
-  "Returns the components of a Java package statement."
+  "Return the components of a Java PACKAGE statement."
   (split-string package "\\."))
 
 (defun eclim--java-current-package ()
-  "Returns the package for the class in the current buffer."
+  "Return the package for the class in the current buffer."
   (save-excursion
     (goto-char 0)
     (if (re-search-forward "package \\(.*?\\);" (point-max) t)
         (match-string-no-properties 1))))
 
-(defun eclim-soft-revert-imports (ignore-auto noconfirm)
-  "Can be used as a REVERT-BUFFER-FUNCTION to only replace the
-imports section of a java source file. This will preserve the
-undo history."
+(defun eclim-soft-revert-imports (_ignore-auto _noconfirm)
+  "Can be used as a REVERT-BUFFER-FUNCTION to only replace the imports section \
+of a java source file.  This will preserve the undo history."
   (interactive)
-  (ignore ignore-auto noconfirm)
   (cl-flet ((cut-imports ()
-                         (goto-char (point-min))
-                         (if (re-search-forward "^import" nil t)
-                             (progn
-                               (beginning-of-line)
-                               (let ((beg (point)))
-                                 (goto-char (point-max))
-                                 (re-search-backward "^import")
-                                 (end-of-line)
-                                 (let ((imports (buffer-substring-no-properties beg (point))))
-                                   (delete-region beg (point))
-                                   imports)))
-                           (progn
-                             (goto-char (point-min))
-                             (if (re-search-forward "^package" nil t)
-                                 (forward-line 1))
-                             (delete-blank-lines)
-                             (insert "\n\n\n")
-                             (forward-line -2)))))
+              (goto-char (point-min))
+              (if (re-search-forward "^import" nil t)
+                  (progn
+                    (beginning-of-line)
+                    (let ((beg (point)))
+                      (goto-char (point-max))
+                      (re-search-backward "^import")
+                      (end-of-line)
+                      (let ((imports (buffer-substring-no-properties beg (point))))
+                        (delete-region beg (point))
+                        imports)))
+                (progn
+                  (goto-char (point-min))
+                  (if (re-search-forward "^package" nil t)
+                      (forward-line 1))
+                  (delete-blank-lines)
+                  (insert "\n\n\n")
+                  (forward-line -2)))))
     (let* ((fname (buffer-file-name))
            (new-imports (with-temp-buffer
                           (insert-file-contents fname)
@@ -511,8 +559,7 @@ undo history."
         (set-visited-file-modtime)))))
 
 (defun eclim-java-import (type)
-  "Adds an import statement for the given type, if one does not
-exist already."
+  "Add an import statement for the given TYPE, if one does not exist already."
   (unless (save-excursion
             (goto-char (point-min))
             (re-search-forward (format "^import %s;" type) nil t))
@@ -522,43 +569,48 @@ exist already."
       (message "Imported %s" type))))
 
 (defun eclim-java-import-organize (&optional types)
-  "Checks the current file for missing imports, removes unused imports and
-sorts import statements. "
+  "Check the current file for missing imports, remove unused imports and \
+sort import statements.  If TYPES is non-nil, find imports for all listed types."
   (interactive)
   (let ((revert-buffer-function 'eclim-soft-revert-imports))
-    (eclim/with-results res ("java_import_organize" "-p" "-f" "-o" "-e"
-                             (when types (list "-t" (cl-reduce (lambda (a b) (concat a "," b)) types))))
+    (eclim/with-results res
+      ("java_import_organize" "-p" "-f" "-o" "-e"
+       (when types (list "-t" (cl-reduce (lambda (a b) (concat a "," b)) types))))
       (eclim--problems-update-maybe)
       (when (vectorp res)
         (save-excursion
           (eclim-java-import-organize
-           (mapcar (lambda (imports) (eclim--completing-read "Import: " (append imports '()))) res)))))))
-
+           (mapcar (lambda (imports)
+                     (eclim--completing-read "Import: " (append imports '())))
+                   res)))))))
 
 (defun eclim-java-new (project type name-with-package)
-  "Creates a new class"
-  (interactive (list (eclim-project-name)
+  "Create a new class of TYPE.  If PROJECT is nil, it is created in the \
+current directory."
+  (interactive (list (and (not (y-or-n-p "Create in current directory? "))
+                          (eclim-project-name))
                      (eclim--completing-read "Type: " eclim--java-new-types)
                      (read-string "Name: " (eclim--java-current-package))))
   (let ((root-dir (eclim--completing-read "Root: " (eclim/java-src-dirs project))))
     (when eclim-print-debug-messages
-      (message "eclim-java-new: project: %s, type: %s, file: %s" project type name-with-package))
-    (eclim/with-results new-file ("java_new" ("-p" project) ("-t" type) ("-n" name-with-package) ("-r" root-dir))
-      (eclim--find-file new-file)
-    )))
+      (message "eclim-java-new: project: %s, type: %s, file: %s" project type
+               name-with-package))
+    (eclim/with-results new-file ("java_new" ("-p" project) ("-t" type)
+                                  ("-n" name-with-package) ("-r" root-dir))
+      (eclim--find-file new-file))))
 
 (defun eclim--signature-has-keyword (sig java-keyword)
-  "Returns true if a method signature SIG has the keyword JAVA-KEYWORD."
+  "Return non-nil if a method signature SIG has the keyword JAVA-KEYWORD."
   ;; \_< is beginning of identifier E.g. don't match do_abstract".
   (string-match-p (format "\\_<%s\\_>" java-keyword) sig))
 
-
 (defun eclim--colorize-signature (sig)
-  "Minimal colorization for a method signature that we offer for completion,
-so the essential bits stand out from the block of text that ido presents.
-Keep this minimal: more highlighting could easily make things worse not better."
+  "Minimal colorization for a method signature (SIG) that we offer for \
+completion, so the essential bits stand out from the block of text that
+ido presents.  Keep this minimal: more highlighting could easily make things
+worse not better."
   (save-match-data
-    (mapc #'(lambda(re-g-f)             ;; expecting single match per RE
+    (mapc #'(lambda (re-g-f)             ;; expecting single match per RE
               (when (string-match (elt re-g-f 0) sig)
                 (setq sig (replace-match
                            (propertize (match-string (elt re-g-f 1) sig)
@@ -572,11 +624,11 @@ Keep this minimal: more highlighting could easily make things worse not better."
 
 
 (defun eclim-java-implement (&optional name)
-  "Implement or override methods from parents of the class, prompting the
-user to select with a completing read (even if one, as confirmation). If
+  "Implement or override methods from parents of the class, prompting the \
+user to select with a completing read (even if one, as confirmation).  If
 NAME was specified programmatically, filters for that name (strict,
 although only on method name not arguments) and if only one choice
-implement it without prompting. The actual change is done by Eclipse
+implement it without prompting.  The actual change is done by Eclipse
 and will be close to point although not necessarily at it (e.g. if in a
 sub block)."
   (interactive)
@@ -589,65 +641,68 @@ sub block)."
            ;; when we request eclim to implement that method.
            (choice-data (make-hash-table :test 'equal)))
       (cl-loop
-       for super-entry across supertypes do
-       (let* ((package (assoc-default 'packageName super-entry))
-              (super-sig (assoc-default 'signature super-entry))
-              ;; Erase type arguments. This looks like "class List<String>".
-              (friendly-super (replace-regexp-in-string "<[^<]*>" "" super-sig))
-              (full-super (concat package "."
-                                  (replace-regexp-in-string "^\\w+ " ""
-                                                            friendly-super)))
-              (is-interface (eclim--signature-has-keyword
-                             super-sig "interface"))
-              (methods (assoc-default 'methods super-entry))
-              (required-methods nil))   ;; Eclim names here
-         (cl-loop
-          for method across methods
-          ;; Skip if specified name doesn't match.
-          if (or (null name)
-                 (string-match-p (format "\\_<%s(" (regexp-quote name)) method))
-          do
-          ;; This regexp stuff is how vim (and thus eclim) does it. Nothing
-          ;; fancy. If it breaks, Google eclim/java/impl.vim for changes.
-          (let ((name-for-eclim
-                 ;; Remove keywords and return type. \_< begins identifier.
-                 (replace-regexp-in-string "^\\s *[^(]*\\(\\_<[[:alnum:]_]+(\\)"
-                                           "\\1"
-                                           ;; Remove any and all type parameters.
-                                           (replace-regexp-in-string "<[^<]*>" "" method)))
-                ;; For the user, we have very different requirements. I like
-                ;; knowing public and abstract, and the return type. I hate
-                ;; packages -- I'm already implementing this class so I know.
-                (friendly-name
-                 ;; Packages are non-trivial to find (think Map.Entry) but
-                 ;; if we stop at the first capitalized portion we're okay.
-                 (replace-regexp-in-string "\\_<[[:lower:]][[:alnum:]_]+\\."
-                                           "" method))
-                (is-required (or is-interface (eclim--signature-has-keyword
-                                               method "abstract"))))
-            (let ((choice (format "%s [%s]" friendly-name friendly-super)))
-              ;; This is probably overkill but what if our package erasing
-              ;; resulted in duplicates? Use full name then. As in, really full.
-              (when (gethash choice choice-data)
-                (setq choice (format "%s [%s]" name-for-eclim full-super)))
-              (cond (is-required (push choice choices))
-                    ((member full-super '("java.lang.Object")) ; others like it?
-                     (push choice choices-last))
-                    (t (push choice choices-opt)))
-              (puthash choice (list full-super name-for-eclim) choice-data)
-              (when is-required (push name-for-eclim required-methods)))))
-         ;; Since we don't allow multiple selection like Eclipse / vim, let's
-         ;; provide for the cases that matter. Note that full non-abstract
-         ;; overrides are typically a use case for *delegates*.
-         (when (> (length required-methods) 1) ;; 1 method already there
-           (let ((choice
-                  (format "<all %d %s methods from %s>"
-                          (length required-methods)
-                          (cond (is-interface "missing") (name) (t "abstract"))
-                          friendly-super))
-                 (data (cons full-super (reverse required-methods))))
-             (push choice choices) ;; I'll not worry about conflict here.
-             (puthash choice data choice-data)))))
+         for super-entry across supertypes
+         do (let* ((package (assoc-default 'packageName super-entry))
+                   (super-sig (assoc-default 'signature super-entry))
+                   ;; Erase type arguments. This looks like "class List<String>".
+                   (friendly-super (replace-regexp-in-string "<[^<]*>" "" super-sig))
+                   (full-super (concat package "."
+                                       (replace-regexp-in-string "^\\w+ " ""
+                                                                 friendly-super)))
+                   (is-interface (eclim--signature-has-keyword
+                                  super-sig "interface"))
+                   (methods (assoc-default 'methods super-entry))
+                   (required-methods nil))   ;; Eclim names here
+              (cl-loop
+                 for method across methods
+                 ;; Skip if specified name doesn't match.
+                 if (or (null name)
+                        (string-match-p (format "\\_<%s(" (regexp-quote name))
+                                        method))
+                 do
+                 ;; This regexp stuff is how vim (and thus eclim) does it. Nothing
+                 ;; fancy. If it breaks, Google eclim/java/impl.vim for changes.
+                   (let ((name-for-eclim
+                          ;; Remove keywords and return type. \_< begins identifier.
+                          (replace-regexp-in-string
+                           "^\\s *[^(]*\\(\\_<[[:alnum:]_]+(\\)"
+                           "\\1"
+                           ;; Remove any and all type parameters.
+                           (replace-regexp-in-string "<[^<]*>" "" method)))
+                         ;; For the user, we have very different requirements. I like
+                         ;; knowing public and abstract, and the return type. I hate
+                         ;; packages -- I'm already implementing this class so I know.
+                         (friendly-name
+                          ;; Packages are non-trivial to find (think Map.Entry) but
+                          ;; if we stop at the first capitalized portion we're okay.
+                          (replace-regexp-in-string "\\_<[[:lower:]][[:alnum:]_]+\\."
+                                                    "" method))
+                         (is-required (or is-interface (eclim--signature-has-keyword
+                                                        method "abstract"))))
+                     (let ((choice (format "%s [%s]" friendly-name friendly-super)))
+                       ;; This is probably overkill but what if our package
+                       ;; erasing resulted in duplicates? Use full name then. As
+                       ;; in, really full.
+                       (when (gethash choice choice-data)
+                         (setq choice (format "%s [%s]" name-for-eclim full-super)))
+                       (cond (is-required (push choice choices))
+                             ((member full-super '("java.lang.Object")) ; others like it?
+                              (push choice choices-last))
+                             (t (push choice choices-opt)))
+                       (puthash choice (list full-super name-for-eclim) choice-data)
+                       (when is-required (push name-for-eclim required-methods)))))
+              ;; Since we don't allow multiple selection like Eclipse / vim, let's
+              ;; provide for the cases that matter. Note that full non-abstract
+              ;; overrides are typically a use case for *delegates*.
+              (when (> (length required-methods) 1) ;; 1 method already there
+                (let ((choice
+                       (format "<all %d %s methods from %s>"
+                               (length required-methods)
+                               (cond (is-interface "missing") (name) (t "abstract"))
+                               friendly-super))
+                      (data (cons full-super (reverse required-methods))))
+                  (push choice choices) ;; I'll not worry about conflict here.
+                  (puthash choice data choice-data)))))
       ;; Keep inital order, except for our tweaks.
       (setq choices (append (nreverse choices) (reverse choices-opt)
                             (reverse choices-last)))
@@ -684,18 +739,17 @@ sub block)."
 (defun eclim-run-class (&optional editp)
   "Run the current class.
 If optional EDITP is non-nil, edit the command before running
-it. The following format specs are substituted in the eclim command:
+it.  The following format specs are substituted in the eclim command:
 
    %p project name
    %c fully qualified class name
    %r root directory of the current project
 
 See help string of 'eclim ? java` for available
-arguments. Currently available arguments:
+arguments.  Currently available arguments:
 
     java -p project [-d] [-c classname] [-w workingdir]
-         [-v vmargs] [-s sysprops] [-e envargs] [-a args]
-"
+         [-v vmargs] [-s sysprops] [-e envargs] [-a args]"
   (interactive "P")
   (if (not (string= major-mode "java-mode"))
       (message "Sorry cannot run current buffer.")
@@ -744,8 +798,8 @@ arguments. Currently available arguments:
   (eclim--buffer-contains-substring "org.testng.annotations.Test"))
 
 (defun eclim-run-junit (project file offset encoding)
-  "Run the current JUnit tests for current project or
-current class or current method.
+  "Run the current JUnit tests for current PROJECT or \
+current class or current method in FILE at OFFSET with ENCODING.
 
 This method hooks onto the running Eclipse process and is thus
 much faster than running mvn test -Dtest=TestClass#method."
@@ -761,8 +815,8 @@ much faster than running mvn test -Dtest=TestClass#method."
 
 (defun eclim-java-browse-documentation-at-point (&optional arg)
   "Browse the documentation of the element at point.
-With the prefix ARG, ask for pattern. Pattern is a shell glob
-pattern, not a regexp. Rely on `browse-url' to open user defined
+With the prefix ARG, ask for pattern.  Pattern is a shell glob
+pattern, not a regexp.  Rely on `browse-url' to open user defined
 browser."
   (interactive "P")
   (let ((symbol (if arg
@@ -812,15 +866,46 @@ browser."
             (use-local-map eclim-java-show-documentation-map)
 
             (eclim--java-show-documentation-and-format doc)
-
-            (message (substitute-command-keys
-                      (concat
-                       "\\[forward-button] - move to next link, "
-                       "\\[backward-button] - move to previous link, "
-                       "\\[eclim-quit-window] - quit")))))
+            ;; return the docstring
+            (prog1 (buffer-string)
+              (message (substitute-command-keys
+                        (concat
+                         "\\[forward-button] - move to next link, "
+                         "\\[backward-button] - move to previous link, "
+                         "\\[eclim-quit-window] - quit"))))))
 
       (message "No element found at point."))))
 
+;; insert prettified doc string: fills long lines, but tries to maintain proper
+;; paragraph separation using `use-hard-newlines' and add text properties to the
+;; resulting docs
+(defun eclim--java-insert-documentation-formatted (doc)
+  (insert (cdr (assoc 'text doc)))
+  (let ((use-hard-newlines t)
+        (nlnl "\n\n")
+        (nl "\n")
+        (pos (progn (goto-char (point-min)) (forward-line 2) (point)))
+        in-block)
+    (put-text-property 0 1 'hard t nl)
+    (put-text-property 0 1 'hard t nlnl)
+    (while (re-search-forward
+            "\\(\\([:[alpha]:]+\\)? *\\([:\n\t]\\)+\\)" nil 'move)
+      (cond
+       ((string-match-p (match-string 3) ":")
+        (if (not (string-match-p (match-string 3) "\n"))
+            (replace-match (concat nl (concat (match-string 2) ":") nl))
+          (setq in-block t)
+          (replace-match (concat ":" nlnl)) ;start of block
+          (add-text-properties (1- (point)) (point) '(start-block t))))
+       ((and in-block (looking-at-p "\\s-*$")) ;end of block
+        (setq in-block nil)
+        (replace-match nl)
+        (add-text-properties (1- (point)) (point) '(end-block t))
+        (forward-line))
+       ((memq (char-after (point-at-bol)) '(? ?	))
+        (replace-match nl))              ;inside code / output block
+       (t (replace-match nlnl))))
+    (fill-region pos (point-max) nil 'nosqueeze)))
 
 (defun eclim--java-show-documentation-and-format (doc &optional add-to-history)
   (make-local-variable 'eclim-java-show-documentation-history)
@@ -830,13 +915,13 @@ browser."
                   eclim-java-show-documentation-history)))
 
   (erase-buffer)
-  (insert (cdr (assoc 'text doc)))
+  (eclim--java-insert-documentation-formatted doc)
 
   (let ((links (cdr (assoc 'links doc)))
         link placeholder text href)
     (dotimes (i (length links))
       (setq link (aref links i))
-      (setq text (cdr (assoc 'text link)))
+      (setq text (replace-regexp-in-string "</?code>" "" (cdr (assoc 'text link))))
       (setq href (cdr (assoc 'href link)))
       (setq placeholder (format "|%s[%s]|" text i))
       (goto-char (point-min))
@@ -851,11 +936,12 @@ browser."
   (when add-to-history
     (goto-char (point-max))
     (insert "\n\n")
-    (insert-text-button "back" 'follow-link t 'action 'eclim--java-show-documentation-go-back))
-
+    (insert-text-button "back" 'follow-link t 'action
+                        'eclim--java-show-documentation-go-back))
   (goto-char (point-min)))
 
 (defun eclim-java-show-documentation-follow-link (link)
+  "Follow the LINK at point while browsing javadocs."
   (interactive)
   (let ((url (button-get link 'url)))
     (if (string-match "^eclipse-javadoc" url)
@@ -890,10 +976,10 @@ browser."
         (message "There is no handler for this kind of url yet. Implement it! : %s"
                  url)))))
 
-
 (defun eclim--java-show-documentation-go-back (_link)
   (erase-buffer)
   (insert (pop eclim-java-show-documentation-history))
   (goto-char (point-min)))
 
 (provide 'eclim-java)
+;;; eclim-java.el ends here

--- a/eclim-macros.el
+++ b/eclim-macros.el
@@ -27,14 +27,17 @@
 ;; Macros used by this package.
 ;;
 ;;; Code:
+(eval-when-compile (require 'cl-lib))
 
 (defun eclim--args-contains (args flags)
   "Validate that ARGS (not expanded) has the specified FLAGS."
   (cl-loop for f in flags
-           return (cl-find f args :test #'string= :key (lambda (a) (if (listp a) (car a) a)))))
+     return (cl-find f args
+                     :test #'string=
+                     :key (lambda (a) (if (listp a) (car a) a)))))
 
 (defun eclim--evaluating-args-form (args)
-  "Return a form which evaluates the elements of the list ARGS.
+  "Returns a form which evaluates the elements of the list ARGS.
 If a list element is of the form (STRING EXPRESSION), only
 EXPRESSION will be evaluated by the form to some RESULT,
 and \(STRING RESULT) will be the element contained in the
@@ -132,10 +135,13 @@ and also bound to PROBLEMS while evaluating BODY."
   (let ((res (cl-gensym)))
     `(when eclim--problems-project
        (setq eclim--problems-refreshing t)
-       (eclim/with-results-async ,res ("problems" ("-p" eclim--problems-project) (when (string= "e" eclim--problems-filter) '("-e" "true")))
+       (eclim/with-results-async ,res
+         ("problems" ("-p" eclim--problems-project)
+          (when (string= "e" eclim--problems-filter)
+            '("-e" "true")))
          (cl-loop for problem across ,res
-                  do (let ((filecell (assq 'filename problem)))
-                       (when filecell (setcdr filecell (file-truename (cdr filecell))))))
+            do (let ((filecell (assq 'filename problem)))
+                 (when filecell (setcdr filecell (file-truename (cdr filecell))))))
          (setq eclim--problems-list ,res)
          (let ((,problems ,res))
            (setq eclim--problems-refreshing nil)
@@ -155,4 +161,4 @@ current buffer is still live when the closure is called."
              ,@body))))))
 
 (provide 'eclim-macros)
-;;;
+;;; eclim-macros.el ends here

--- a/eclim-maven.el
+++ b/eclim-maven.el
@@ -17,7 +17,6 @@
 ;;
 ;;; Contributors
 ;;
-;;
 ;;; Commentary:
 ;;
 ;;; Conventions
@@ -25,8 +24,8 @@
 ;; Conventions used in this file: Name internal variables and functions
 ;; "eclim--<descriptive-name>", and name eclim command invocations
 ;; "eclim/command-name", like eclim/project-list.
-
-;;* Eclim Maven
+;;
+;;; Code:
 
 (require 'compile)
 (require 'eclim-common)
@@ -41,7 +40,8 @@
 (define-key eclim-mode-map (kbd "C-c C-e m r") 'eclim-maven-run)
 
 (defvar eclim-maven-lifecycle-phases
-  '("validate" "compile" "test" "package" "integration" "verify" "install" "deploy"))
+  '("validate" "compile" "test" "package" "integration" "verify" "install" "deploy")
+  "Maven lifecycle phases.")
 
 (defun eclim--maven-lifecycle-phase-read ()
   (completing-read "Phase: " eclim-maven-lifecycle-phases))
@@ -53,18 +53,17 @@
   (let ((default-directory (eclim--project-dir)))
     (compile (concat "mvn -f " (eclim--maven-pom-path) " " command))))
 
-
-
 (defun eclim-maven-run (goal)
-  "Execute a specific Maven goal in the context of the current
-project. The build output is displayed in the *compilation* buffer."
+  "Execute a specific Maven GOAL in the context of the current project.
+The build output is displayed in the *compilation* buffer."
   (interactive "MGoal: ")
   (eclim--maven-execute goal))
 
 (defun eclim-maven-lifecycle-phase-run (phase)
-  "Run any given Maven life-cycle phase in the context of the current
-project. The build output is displayed in the *compilation* buffer."
+  "Run any given Maven life-cycle PHASE in the context of the current project.
+The build output is displayed in the *compilation* buffer."
   (interactive (list (eclim--maven-lifecycle-phase-read)))
   (eclim-maven-run phase))
 
 (provide 'eclim-maven)
+;;; eclim-maven.el ends here

--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -23,8 +23,6 @@
 ;;  - Alessandro Arzilli <alessandro.arzilli * gmail com>
 ;;
 ;;; Commentary:
-;;
-;;
 ;;; Code:
 
 (require 'popup)
@@ -251,7 +249,8 @@ If the problems buffer does not exist yet, it is created."
   (interactive)
   (if (eclim-project-name)
       (eclim--problems-mode-init)
-    (error "Could not figure out the current project. Is this an eclim managed buffer?")))
+    (error "Could not figure out the current project.  \
+Is this an eclim managed buffer?")))
 
 (defun eclim-problems-open ()
   "Switch to the problems buffer in a new Emacs window.

--- a/eclim-project.el
+++ b/eclim-project.el
@@ -25,13 +25,13 @@
 ;; Conventions used in this file: Name internal variables and functions
 ;; "eclim--<descriptive-name>", and name eclim command invocations
 ;; "eclim/command-name", like eclim/project-list.
+;;
+;;; Code:
 
-;;* Eclim Project
-
-(eval-when-compile (require 'cl))
-(require 'cl-lib)
 (require 'eclim-common)
-(eval-when-compile (require 'eclim-macros))
+(eval-when-compile
+  (require 'eclim-macros)
+  (require 'cl-lib))
 
 (defvar eclim-project-mode-hook nil)
 (defvar eclim-project-info-mode-hook nil)
@@ -65,7 +65,6 @@
     (set-keymap-parent map special-mode-map)
         map))
 
-
 (define-key eclim-mode-map (kbd "C-c C-e g") 'eclim-project-goto)
 (define-key eclim-mode-map (kbd "C-c C-e p p") 'eclim-project-mode)
 (define-key eclim-mode-map (kbd "C-c C-e p m") 'eclim-project-mode)
@@ -73,25 +72,33 @@
 (define-key eclim-mode-map (kbd "C-c C-e p c") 'eclim-project-create)
 (define-key eclim-mode-map (kbd "C-c C-e p g") 'eclim-project-goto)
 
+;; Clear project caches.
 (defun eclim--project-clear-cache ()
   (setq eclim--project-natures-cache nil)
   (setq eclim--projects-cache nil))
 
+;; Check project NATURE.
 (defun eclim--check-nature (nature)
   (let ((natures (or eclim--project-natures-cache
-                    (setq eclim--project-natures-cache (eclim/project-nature-aliases)))))
+                     (setq eclim--project-natures-cache
+                           (eclim/project-nature-aliases)))))
     (when (not (member nature (append natures nil)))
       (error "Invalid project nature: %s" nature))))
 
 (defun eclim--project-read (&optional single)
+  "Read eclim project.
+When in `eclim-project-mode' returns name of project
+on current line if SINGLE is non-nil, otherwise returns all marked projects."
   (interactive)
   (if (eq major-mode 'eclim-project-mode)
       (progn
         (or (if single nil (eclim--project-get-marked))
             (eclim--project-current-line)))
-    (eclim--completing-read "Project: "
-                            (mapcar (lambda (p) (assoc-default 'name p)) (eclim/project-list)))))
+    (eclim--completing-read
+     "Project: " (mapcar (lambda (p) (assoc-default 'name p))
+                         (eclim/project-list)))))
 
+;; Clears project cache. From `eclim-project-mode', update project buffer.
 (defun eclim--project-buffer-refresh ()
   (eclim--project-clear-cache)
   (when (eq major-mode 'eclim-project-mode)
@@ -103,12 +110,15 @@
       (goto-char (point-min))
       (forward-line (1- line-number)))))
 
+;; Insert PROJECT info line in `eclim-project-mode'.
 (defun eclim--insert-project (project)
-  (insert (format "  | %-6s | %-30s | %s\n"
-                  (if (eq :json-false (assoc-default 'open project)) "closed" "open")
-                  (truncate-string-to-width (assoc-default 'name project) 30 0 nil t)
-                  (assoc-default 'path project))))
+  (insert
+   (format "  | %-6s | %-30s | %s\n"
+           (if (eq :json-false (assoc-default 'open project)) "closed" "open")
+           (truncate-string-to-width (assoc-default 'name project) 30 0 nil t)
+           (assoc-default 'path project))))
 
+;; Mark current project in `eclim-project-mode' with FACE.
 (defun eclim--project-insert-mark-current (face)
   (let ((inhibit-read-only t))
     (save-excursion
@@ -117,6 +127,7 @@
       (insert "*")
       (put-text-property (- (point) 1) (point) 'face face))))
 
+;; Remove mark from current project in `eclim-project-mode'.
 (defun eclim--project-remove-mark-current ()
   (let ((inhibit-read-only t))
     (save-excursion
@@ -124,8 +135,9 @@
       (delete-char 1)
       (insert " "))))
 
+;; Return list of marked projects in `eclim-project-mode'.
 (defun eclim--project-get-marked ()
-  (interactive)
+  ;; (interactive)
   (let ((marked-projects '()))
     (save-excursion
       (goto-char (point-min))
@@ -133,14 +145,17 @@
         (push (eclim--project-current-line) marked-projects)))
     marked-projects))
 
+;; Determine COLUMN starting location in `eclim-project-mode'.
 (defun eclim--project-column-start (column)
   (save-excursion
     (+ (re-search-forward "|" nil t (- column 1)) 1)))
 
+;; Determine COLUMN ending location in `eclim-project-mode'.
 (defun eclim--project-column-end (column)
   (save-excursion
     (- (re-search-forward "|" nil t column) 1)))
 
+;; Return name of project on current line in `eclim-project-mode'.
 (defun eclim--project-current-line ()
   (save-excursion
     (beginning-of-line)
@@ -156,22 +171,28 @@
   ;; TODO: allow multiple natures
   ;; add the vars target,package,application for android project
   (eclim--project-clear-cache)
-  (eclim--call-process "project_create" "-f" folder "-n" natures "-p" name "-a" "--target" target "--package" package "--application" application))
+  (eclim--call-process "project_create" "-f" folder "-n" natures
+                       "-p" name "-a" "--target" target "--package" package
+                       "--application" application))
 
 (defun eclim/project-delete (project)
+  "Deletes PROJECT and clears cache."
   (eclim--check-project project)
   (eclim--project-clear-cache)
   (eclim--call-process "project_delete" "-p" project))
 
 (defun eclim/project-open (project)
+  "Open PROJECT."
   (eclim--check-project project)
   (eclim--call-process "project_open" "-p" project))
 
 (defun eclim/project-close (project)
+  "Close PROJECT."
   (eclim--check-project project)
   (eclim--call-process "project_close" "-p" project))
 
 (defun eclim/project-settings (project)
+  "Check PROJECT settings."
   (eclim--check-project project)
   ;; TODO: make the output useable
   (eclim--call-process "project_settings" "-p" project))
@@ -232,17 +253,21 @@
          (value (read-string (concat "value " prev-value ": "))))
     (eclim/project-setting-set project setting value)))
 
+;; return project classpath for the current buffer.
 (defun eclim/project-classpath (&optional delimiter)
-  "return project classpath for the current buffer."
   (eclim/execute-command "java_classpath" "-p" ("-d" delimiter)))
 
 (defun eclim-project-rename (project name)
-  (interactive (let ((project-name (eclim--project-read t)))
-                 (list project-name (read-string (concat "Rename <" project-name "> To: ")))))
+  "Rename PROJECT (at point if in project buffer) with NAME."
+  (interactive
+   (let ((project-name (eclim--project-read t)))
+     (list project-name (read-string
+                         (concat "Rename <" project-name "> To: ")))))
   (message (eclim/project-rename project name))
   (eclim--project-buffer-refresh))
 
 (defun eclim-project-delete (projects)
+  "Delete PROJECTS (all marked projects from project buffer)."
   (interactive (list (eclim--project-read)))
   (when (not (listp projects)) (setq projects (list projects)))
   (dolist (project projects)
@@ -251,6 +276,7 @@
   (eclim--project-buffer-refresh))
 
 (defun eclim-project-create (name path nature)
+  "Create a project with NAME, PATH, and NATURE."
   (interactive (list (read-string "Name: ")
                      (expand-file-name (read-directory-name "Project Directory: "))
                      (eclim--project-nature-read)))
@@ -260,11 +286,13 @@
         (let ((target (read-string "Target: "))
               (package (read-string "Package: "))
               (application (read-string "Application: ")))
-          (message (eclim/project-create path nature name target package application))))
+          (message (eclim/project-create
+                    path nature name target package application))))
     (message (eclim/project-create path nature name))
     (eclim--project-buffer-refresh)))
 
 (defun eclim-project-import (folder)
+  "Import project from FOLDER and update project buffer."
   (interactive "DProject Directory: ")
   (message (eclim/project-import folder))
   (eclim--project-buffer-refresh))
@@ -273,30 +301,40 @@
   (completing-read "Nature: " (append (eclim/project-nature-aliases) nil)))
 
 (defun eclim-project-nature-add (nature)
+  "Add NATURE to project."
   (interactive (list (eclim--project-nature-read)))
   (message (eclim/project-nature-add (eclim--project-current-line) nature)))
 
 (defun eclim-project-nature-remove (nature)
-  (interactive (list (completing-read "Remove nature: "
-                                      (append
-                                       (cl-cdadr (aref (eclim/project-natures (eclim--project-current-line)) 0))
-                                       nil))))
+  "Remove NATURE from project."
+  (interactive
+   (list (completing-read
+          "Remove nature: " (append
+                             (cl-cdadr (aref (eclim/project-natures
+                                              (eclim--project-current-line))
+                                             0))
+                             nil))))
   (message (eclim/project-nature-remove (eclim--project-current-line) nature)))
 
 (defun eclim-project-natures ()
+  "Print project natures for project on current line in `eclim-project-mode'."
   (interactive)
   (message (with-output-to-string
-             (princ (cl-cdadr (aref (eclim/project-natures (eclim--project-current-line)) 0))))))
+             (princ
+              (cl-cdadr
+               (aref (eclim/project-natures (eclim--project-current-line)) 0))))))
 
 (defun eclim-project-dependencies (project)
   (cdr (assoc 'depends (eclim/project-info project))))
 
 (defun eclim-project-mode-refresh ()
+  "Refresh `eclim-project-mode' buffer."
   (interactive)
   (eclim--project-buffer-refresh)
   (message "projects refreshed..."))
 
 (defun eclim-project-update (projects)
+  "Update PROJECTS (all marked from project buffer)."
   (interactive (list (eclim--project-read)))
   (when (not (listp projects)) (setq projects (list projects)))
   (dolist (project projects)
@@ -304,6 +342,7 @@
   (eclim--project-buffer-refresh))
 
 (defun eclim-project-open (projects)
+  "Open PROJECTS (all marked from project buffer)."
   (interactive (list (eclim--project-read)))
   (when (not (listp projects)) (setq projects (list projects)))
   (dolist (project projects)
@@ -311,6 +350,7 @@
   (eclim--project-buffer-refresh))
 
 (defun eclim-project-close (projects)
+  "Close PROJECTS (all those marked from project buffer)."
   (interactive (list (eclim--project-read)))
   (when (not (listp projects)) (setq projects (list projects)))
   (dolist (project projects)
@@ -318,6 +358,7 @@
   (eclim--project-buffer-refresh))
 
 (defun eclim-project-refresh (projects)
+  "Refresh PROJECTS (all those marked from project buffer)."
   (interactive (list (eclim--project-read)))
   (when (not (listp projects)) (setq projects (list projects)))
   (dolist (project projects)
@@ -325,20 +366,27 @@
   (eclim--project-buffer-refresh))
 
 (defun eclim-project-refresh-file (projects)
+  "Refresh current file in PROJECTS (all those marked from project buuffer)."
   (interactive (list (eclim--project-read)))
   (when (not (listp projects)) (setq projects (list projects)))
   (dolist (project projects)
     (let ((file (buffer-file-name (current-buffer)))
-          (project-dir (concat (file-name-as-directory (eclim/workspace-dir)) project)))
-      (eclim/project-refresh-file project (substring file (- (string-width project-dir) (string-width file)) nil))))
+          (project-dir
+           (concat (file-name-as-directory (eclim/workspace-dir)) project)))
+      (eclim/project-refresh-file
+       project (substring file (- (string-width project-dir)
+                                  (string-width file))
+                          nil))))
   (eclim--project-buffer-refresh))
 
 (defun eclim-project-mark-current ()
+  "Mark current project in `eclim-project-mode'."
   (interactive)
   (eclim--project-insert-mark-current 'dired-mark)
   (forward-line 1))
 
 (defun eclim-project-mark-all ()
+  "Mark all projects in `eclim-project-mode'."
   (interactive)
   (save-excursion
     (goto-char (point-min))
@@ -346,11 +394,13 @@
              until (not (forward-line 1)))))
 
 (defun eclim-project-unmark-current ()
+  "Unmark project on current line in `eclim-project-mode'."
   (interactive)
   (eclim--project-remove-mark-current)
   (forward-line 1))
 
 (defun eclim-project-unmark-all ()
+  "Umark all projects in `eclim-project-mode'."
   (interactive)
   (save-excursion
     (goto-char (point-min))
@@ -358,6 +408,7 @@
              until (not (forward-line 1)))))
 
 (defun eclim-project-goto (project)
+  "Find file in PROJECT."
   (interactive (list (eclim--project-read t)))
   (ido-find-file-in-dir
    (assoc-default 'path
@@ -366,7 +417,7 @@
                         :test #'string=))))
 
 (defun eclim-project-info-mode (project)
-  "Display detailed information about an eclim-project.
+  "Display detailed information about eclim-project PROJECT.
 
 \\{eclim-project-info-mode-map}"
   (interactive (list (eclim--project-read t)))
@@ -375,10 +426,11 @@
       (kill-all-local-variables)
       (save-excursion
         (cl-loop for attr in (eclim/project-info project)
-                 do (princ (format "%s: %s\n" (car attr) (cdr attr))))
+           do (princ (format "%s: %s\n" (car attr) (cdr attr))))
         (princ "\n\nSETTINGS:\n")
         (cl-loop for attr across (eclim/project-settings project)
-                 do (princ (format "%s: %s\n" (assoc-default 'name attr) (assoc-default 'value attr))))
+           do (princ (format "%s: %s\n" (assoc-default 'name attr)
+                             (assoc-default 'value attr))))
         (use-local-map eclim-project-info-mode-map)
         (setq major-mode 'eclim-project-info-mode
               mode-name "eclim/project-info")
@@ -386,7 +438,7 @@
         (run-mode-hooks eclim-project-info-mode-hook)))))
 
 (defun eclim-project-build ()
-  "Triggers a build of the current project"
+  "Triggers a build of the current project."
   (interactive)
   (eclim/execute-command-async
    (lambda (res) (message res))
@@ -420,3 +472,4 @@
 (defalias 'eclim-manage-projects 'eclim-project-mode)
 
 (provide 'eclim-project)
+;;; eclim-project.el ends here

--- a/eclim-scala.el
+++ b/eclim-scala.el
@@ -19,7 +19,6 @@
 ;;
 ;; - Shuai Lin <linshuai2012@gmail.com>
 ;;
-;;
 ;;; Commentary:
 ;;
 ;;; Conventions
@@ -27,6 +26,8 @@
 ;; Conventions used in this file: Name internal variables and functions
 ;; "eclim--<descriptive-name>", and name eclim command invocations
 ;; "eclim/command-name", like eclim/project-list.
+;;
+;;; Code:
 
 ;;* Eclim Scala
 
@@ -49,3 +50,4 @@
       (eclim--find-display-results (cdr i) hits t))))
 
 (provide 'eclim-scala)
+;;; eclim-scala.el ends here

--- a/eclim.el
+++ b/eclim.el
@@ -30,19 +30,20 @@
 ;;
 ;;; Commentary:
 ;;
-;; Emacs-eclim uses the Eclim Server to integrate eclipse with Emacs.  This project wants to bring
-;; some of the invaluable features from Eclipse to Emacs.  Please note, the eclim package is limited
-;; to mostly Java support at this time.
+;; Emacs-eclim uses the Eclim Server to integrate eclipse with Emacs.  This
+;; project wants to bring some of the invaluable features from Eclipse to Emacs.
+;; Please note, the eclim package is limited to mostly Java support at this
+;; time.
 ;;
 ;;; Code:
 
-(eval-when-compile (require 'cl))
-(require 'cl-lib)
 (require 's)
 (require 'json)
 (require 'eclimd)
 (require 'eclim-common)
-(eval-when-compile (require 'eclim-macros))
+(eval-when-compile
+  (require 'eclim-macros)
+  (require 'cl-lib))
 
 ;;** Basics
 
@@ -179,7 +180,8 @@ may define more families in the future."
         (add-hook 'after-save-hook 'eclim--problems-update-maybe nil t)
         (add-hook 'after-save-hook 'eclim--after-save-hook nil t)
         (advice-add 'find-file :after #'eclim-problems-advice-find-file)
-        (advice-add 'find-file-other-window :after #'eclim-problems-advice-find-file-other-window)
+        (advice-add 'find-file-other-window
+                    :after #'eclim-problems-advice-find-file-other-window)
         (advice-add 'other-window :after #'eclim-problems-advice-other-window)
         (advice-add 'switch-to-buffer :after #'eclim-problems-advice-switch-to-buffer)
         (advice-add 'delete-file :around #'eclim-java-delete-file)
@@ -190,7 +192,8 @@ may define more families in the future."
     (remove-hook 'after-save-hook 'eclim--after-save-hook t)
     (advice-remove 'find-file #'eclim-problems-highlight)
     (advice-remove 'find-file #'eclim-problems-advice-find-file)
-    (advice-remove 'find-file-other-window #'eclim-problems-advice-find-file-other-window)
+    (advice-remove 'find-file-other-window
+                   #'eclim-problems-advice-find-file-other-window)
     (advice-remove 'other-window #'eclim-problems-advice-other-window)
     (advice-remove 'switch-to-buffer #'eclim-problems-advice-switch-to-buffer)
     (advice-remove 'delete-file #'eclim-java-delete-file)))
@@ -221,7 +224,7 @@ or not a new project should be created to contain the
 current file."
   (when (and (not (eclim-project-name))
              (y-or-n-p "Eclim mode was enabled in a buffer \
-that is not organized in a Eclipse project. Create a new project? "))
+that is not organized in a Eclipse project.  Create a new project? "))
     (call-interactively 'eclim-project-create)))
 
 ;;;###autoload
@@ -232,10 +235,10 @@ that is not organized in a Eclipse project. Create a new project? "))
   "Used to prevent recursive calls to function `global-eclim-mode'.
 Such recursive calls are possible because
 `eclimd--ensure-started' may create a comint buffer for
-which Emacs checks whether `eclim-mode' should be enabled.")
+which Emacs checks whether command `eclim-mode' should be enabled.")
 
 (defun eclim--enable-for-accepted-files-in-project ()
-  "Enable `eclim-mode' in accepted files that belong to a project.
+  "Enable command `eclim-mode' in accepted files that belong to a project.
 A file is accepted if it's name is matched by any of
 `eclim-accepted-file-regexps' elements.  Note that in order
 to determine if a file is managed by a project, eclimd is
@@ -246,10 +249,12 @@ required to be running and will thus be autostarted."
       (let ((eclim--enable-for-accepted-files-in-project-running t))
         (when (and buffer-file-name
                    (eclim--accepted-filename-p buffer-file-name))
-          (eclimd--ensure-started t (eclim--lambda-with-live-current-buffer
-                                      (when (and (eclim--file-managed-p buffer-file-name)
-                                                 (eclim--project-dir))
-                                        (eclim-mode 1)))))))))
+          (eclimd--ensure-started
+           t
+           (eclim--lambda-with-live-current-buffer
+             (when (and (eclim--file-managed-p buffer-file-name)
+                        (eclim--project-dir))
+               (eclim-mode 1)))))))))
 
 (require 'eclim-ant)
 (require 'eclim-debug)

--- a/eclimd.el
+++ b/eclimd.el
@@ -31,9 +31,16 @@
 ;;; Code:
 
 (require 'eclim-common)
-(require 'cl-lib)
-(require 'dash)
-(eval-when-compile (require 'eclim-macros))
+;; (require 'dash)
+(eval-when-compile
+  (require 'eclim-macros)
+  (require 'cl-lib))
+
+;;;###autoload(defalias 'start-eclimd 'eclimd-start)
+(defalias 'stop-eclimd 'eclimd-stop)
+
+;; (define-obsolete-function-alias 'start-eclimd 'eclimd-start "27")
+;; (define-obsolete-function-alias 'stop-eclimd 'eclimd-stop "27")
 
 (defgroup eclimd nil
   "eclimd customizations"
@@ -45,7 +52,7 @@
   "The eclimd executable to use.
 Set to nil to auto-discover from `eclim-executable' value
 \(the default).  Set to \"eclimd\" if eclim and eclimd are
-in `exec-path'.  Otherwise, set to the full path of the
+in function `exec-path'.  Otherwise, set to the full path of the
 eclimd executable."
   :type '(choice (const :tag "Same directory as eclim-executable variable" nil)
                  (string :tag "Custom value" "eclimd"))
@@ -53,14 +60,14 @@ eclimd executable."
 
 (defcustom eclimd-default-workspace
   "~/workspace"
-  "The default value to use when `start-eclimd' asks for a workspace."
+  "The default value to use when `eclimd-start' asks for a workspace."
   :type 'directory
   :group 'eclimd)
 
 (defcustom eclimd-wait-for-process
   nil
-  "Non-nil means `start-eclimd' blocks until eclimd is ready.
-When this variable is nil, `start-eclimd' returns
+  "Non-nil means `eclimd-start' blocks until eclimd is ready.
+When this variable is nil, `eclimd-start' returns
 immediately after the eclimd process is started.  Since the
 eclimd process startup takes a few seconds, running eclim
 commands immediately after the function returns may cause
@@ -110,7 +117,7 @@ on which eclimd is serving.")
 When `eclimd-autostart' is non-nil, this option controls
 whether eclimd is started silently with the workspace set to
 `eclimd-default-workspace', or whether the user is asked for
-a workspace as with regular calls to `start-eclimd'."
+a workspace as with regular calls to `eclimd-start'."
   :tag "Autostart eclimd with default workspace"
   :type 'boolean
   :group 'eclimd)
@@ -128,11 +135,10 @@ user is asked to provide the workspace.  Otherwise,
   nil
   "Non-nil means automatically start eclimd within Emacs when needed.
 You may want to set this to nil if you prefer starting
-eclimd manually and don't want it to run as a child
-process of Emacs.  When set, eclimd gets started either when
-`eclim-mode' is enabled or the first time
-`global-eclim-mode' needs it to determine if `eclim-mode'
-should be enabled in a buffer.  See also
+eclimd manually and don't want it to run as a child process of Emacs.
+When set, eclimd gets started either when command `eclim-mode' is enabled
+for the first time function `global-eclim-mode' needs it to determine if
+command `eclim-mode' should be enabled in a buffer.  See also
 `eclimd-autostart-with-default-workspace'."
   :tag "Autostart eclimd"
   :type 'boolean
@@ -234,7 +240,7 @@ start."
        (when callback (funcall callback))))))
 
 ;;;###autoload
-(defun start-eclimd (workspace-dir &optional callback)
+(defun eclimd-start (workspace-dir &optional callback)
   "Start the eclimd server and optionally wait for it to be ready.
 
 WORKSPACE-DIR is the desired workspace directory for which
@@ -249,7 +255,7 @@ block until eclimd is ready to receive commands, depending
 on the value of `eclimd-wait-for-process'.  Commands will
 fail if they are executed before the server is ready.
 
-To stop the server, you should use `stop-eclimd'."
+To stop the server, you should use `eclimd-start'."
   (interactive (list (eclimd--read-workspace-dir)))
   (let ((eclimd-prog (eclimd--executable-path)))
     (if (not eclimd-prog)
@@ -264,12 +270,13 @@ To stop the server, you should use `stop-eclimd'."
                            eclimd-prog
                            nil
                            (concat "-Dosgi.instance.area.default="
-                                   (replace-regexp-in-string "~" "@user.home" workspace-dir))))
+                                   (replace-regexp-in-string "~" "@user.home"
+                                                             workspace-dir))))
         (setq eclimd-process (get-buffer-process eclimd-process-buffer))
         (setq eclimd--comint-process-filter (process-filter eclimd-process))
         (set-process-filter eclimd-process 'eclimd--process-filter)
         (set-process-sentinel eclimd-process 'eclimd--process-sentinel)
-        (add-hook 'kill-emacs-hook #'stop-eclimd)
+        (add-hook 'kill-emacs-hook #'eclimd-stop)
         ;; The flag is required because on exit Emacs asks the user about
         ;; running processes before running the `kill-emacs-hook'.
         (set-process-query-on-exit-flag eclimd-process nil)
@@ -303,14 +310,15 @@ not be started / is already running, CALLBACK is not executed."
         (eclimd--await-connection async callback)
       (if eclimd-autostart
           (let ((eclimd-wait-for-process (not async)))
-            (start-eclimd (eclimd--autostart-workspace) callback))
-        (let ((msg "Autostarting of eclimd is disabled, please start eclimd manually."))
+            (eclimd-start (eclimd--autostart-workspace) callback))
+        (let ((msg "Autostarting of eclimd is disabled, please start eclimd \
+manually."))
           (if async (message msg) (error "%s" msg)))))))
 
-(defun stop-eclimd ()
+(defun eclimd-stop ()
   "Gracefully terminate the eclimd process.
 Also kill the *eclimd*-buffer and remove any hooks added by
-`start-eclimd'."
+`eclimd-start'."
   (interactive)
   (when eclimd-process
     (when (eclim--connected-p)
@@ -321,7 +329,7 @@ Also kill the *eclimd*-buffer and remove any hooks added by
   (when eclimd-process-buffer
     (kill-buffer eclimd-process-buffer)
     (setq eclimd-process-buffer nil))
-  (remove-hook 'kill-emacs-hook #'stop-eclimd))
+  (remove-hook 'kill-emacs-hook #'eclimd-stop))
 
 (provide 'eclimd)
 ;;; eclimd ends here

--- a/maint/eclim-lint.el
+++ b/maint/eclim-lint.el
@@ -26,6 +26,14 @@
 
 (require 'f)
 
+(eval-when-compile
+  (defvar checkdoc-force-docstrings-flag)
+  (defvar checkdoc-arguments-in-order-flag) ;default changed 26.1
+  (defvar checkdoc-verb-check-experimental-flag)
+  (defvar elisp-lint-ignored-validators))
+(declare-function elisp-lint-files-batch "elisp-lint")
+(declare-function flycheck-package-setup "flycheck-package")
+
 (defvar eclim-test-path
   (f-dirname (f-this-file)))
 
@@ -39,7 +47,8 @@
   "Initialize Emacs with Cask packages an invoke ACTION."
   (let* ((load-prefer-newer t)
          (source-directory (locate-dominating-file eclim-test-path "Cask"))
-         (pkg-rel-dir (format ".cask/%s.%S/elpa" emacs-major-version emacs-minor-version)))
+         (pkg-rel-dir
+          (format ".cask/%s.%S/elpa" emacs-major-version emacs-minor-version)))
 
     (setq package-user-dir (expand-file-name pkg-rel-dir source-directory))
     (package-initialize)
@@ -61,12 +70,16 @@
      (add-hook 'emacs-lisp-mode-hook
                (lambda ()
                  (setq indent-tabs-mode nil)
-                 (setq fill-column 80)))
+                 (setq fill-column 80)
+                 (setq checkdoc-force-docstrings-flag nil
+                       checkdoc-arguments-in-order-flag nil ;default changed 26.1
+                       checkdoc-verb-check-experimental-flag nil)))
      (let ((debug-on-error t))
        (elisp-lint-files-batch)))))
 
 (defun eclim-package-lint ()
-  "Checks that the metadata in Emacs Lisp files which to ensure they are intended to be packages."
+  "Checks that the metadata in Emacs Lisp files which to ensure they are
+intended to be packages."
   (eclim-emacs-init
    (lambda ()
      (eval-after-load 'flycheck

--- a/test/company-emacs-eclim-test.el
+++ b/test/company-emacs-eclim-test.el
@@ -22,6 +22,7 @@
 ;;; Code:
 
 (require 'company-emacs-eclim)
+(eval-when-compile (require 'cl))
 (require 'noflet)
 
 (ert-deftest compute-full-prefix-when-complete-import ()

--- a/test/eclim-common-test.el
+++ b/test/eclim-common-test.el
@@ -22,7 +22,6 @@
 ;;; Code:
 
 (require 'eclim-common "eclim-common.el")
-(require 'cl)
 
 (ert-deftest java-accepted-filename-p-test ()
   (should (equal (eclim--accepted-filename-p "test.java") t)))

--- a/test/parser-test.el
+++ b/test/parser-test.el
@@ -21,7 +21,7 @@
 
 ;;; Code:
 
-(ert-deftest java-parser-read-complex-signarure()
+(ert-deftest java-parser-read-complex-signarure ()
   (should (equal (eclim--java-parser-read "public Message<?> preSend(org.springframework.integration.Message<?>,org.springframework.integration.MessageChannel)")
                  '(public Message ((\?)) preSend ((org\.springframework\.integration\.Message ((\?))) (org\.springframework\.integration\.MessageChannel))))))
 

--- a/test/specs/test-eclim-common.el
+++ b/test/specs/test-eclim-common.el
@@ -101,7 +101,7 @@
                     (it "should throw an error for a bad support"
                         (let ((support-types
                                '(xml_complete groovy_complete ruby_complete c_complete php_complete scala_complete)))
-                          (loop
+                          (cl-loop
                            for support-type in support-types
                            do (expect (eclim--parse-result (format "No command '%s' found" support-type))
                                       :to-throw 'error))))


### PR DESCRIPTION
Passes linting tests
removes cl dependencies (except one remains in testing code)
some formatting for javadocs
allows java_new to create classes in current directory