### PR TITLE
fix formatting for lint and remove cl deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: emacs-lisp
+language: generic
 sudo: false
 dist: trusty
 env:

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,27 @@
 # makefie for emacs-eclim
 
-EL_FILES := $(sort $(wildcard *.el))
-ELC_FILES := $(EL_FILES:.el=.elc)
+EL_FILES        := $(sort $(wildcard *.el))
+ELC_FILES       := $(EL_FILES:.el=.elc)
 
-EMACS := emacs
-CASK := cask
-LOAD_PATH := -L .
-EMACS_OPTS :=
-EMACS_BATCH := $(EMACS) -Q -batch -L . $(EMACS_OPTS)
+EMACS           := emacs
+CASK            := cask
+LOAD_PATH       := -L .
+EMACS_OPTS      :=
+EMACS_BATCH     := $(EMACS) -Q -batch -L . $(EMACS_OPTS)
+
 LINT_LOAD_FILES = -l maint/eclim-lint.el
+LINT_FILES      = $(filter-out %-pkg.el,${EL_FILES})
 
 # Program availability
 ifdef CASK
-RUN_EMACS = $(CASK) exec $(EMACS_BATCH)
-HAVE_CASK := $(shell sh -c "command -v $(CASK)")
+RUN_EMACS       = $(CASK) exec $(EMACS_BATCH)
+HAVE_CASK       := $(shell sh -c "command -v $(CASK)")
 ifndef HAVE_CASK
 $(warning "$(CASK) is not available.  Please run make help")
 endif
 endif
 
-VPATH := .
+VPATH           := .
 
 all: test
 
@@ -33,8 +35,8 @@ test:
 specs:
 	$(CASK) exec buttercup -L . -L ./test/specs
 
-lint: $(EL_FILES)
-	$(RUN_EMACS) $(LINT_LOAD_FILES) -f eclim-lint-files $(EL_FILES)
+lint: $(LINT_FILES)
+	$(RUN_EMACS) $(LINT_LOAD_FILES) -f eclim-lint-files $(LINT_FILES)
 
 package-lint: $(EL_FILES)
 	$(RUN_EMACS) $(LINT_LOAD_FILES) -f eclim-package-lint $(EL_FILES)

--- a/ac-emacs-eclim.el
+++ b/ac-emacs-eclim.el
@@ -83,8 +83,8 @@
 ;;;###autoload
 (defun ac-emacs-eclim-config ()
   (add-hook 'java-mode-hook 'ac-emacs-eclim-java-setup)
-  (add-hook 'groovy-mode-hook '(lambda ()
-                                 (add-to-list 'ac-sources 'ac-source-emacs-eclim)))
+  (add-hook 'groovy-mode-hook
+            '(lambda () (add-to-list 'ac-sources 'ac-source-emacs-eclim)))
   (add-hook 'xml-mode-hook 'ac-emacs-eclim-xml-setup)
   (add-hook 'nxml-mode-hook 'ac-emacs-eclim-xml-setup)
   (add-hook 'php-mode-hook 'ac-emacs-eclim-php-setup)

--- a/company-emacs-eclim.el
+++ b/company-emacs-eclim.el
@@ -1,4 +1,4 @@
-;;; company-emacs-eclim.el --- company-mode backend for eclim  -*- lexical-binding: t -*-
+;;; company-emacs-eclim.el --- Eclim company backend -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2009-2012   Fredrik Appelberg
 ;; Copyright (C) 2013-2014   Dmitry Gutov
@@ -30,7 +30,7 @@
 (require 'eclim-completion)
 (require 'eclim-java)
 (require 'company)
-(require 'cl-lib)
+(eval-when-compile (require 'cl-lib))
 
 (defcustom company-emacs-eclim-ignore-case t
   "If t, case is ignored in completion matches."
@@ -40,15 +40,16 @@
 
 ;;;###autoload
 (defun company-emacs-eclim-setup ()
-  "Convenience function that adds company-emacs-eclim to the list
-  of available company backends."
+  "Convenience function that adds ‘company-emacs-eclim’ to the list \
+of available company backends."
   (setq company-backends
         (cons 'company-emacs-eclim
               (cl-remove-if (lambda (b) (cl-find b '(company-nxml company-eclim)))
                             company-backends))))
 
 (defun company-emacs-eclim--before-prefix-in-buffer (prefix)
-  "Search for the text before prefix that may be included as part of completions"
+  "Search for the text before PREFIX that may be included as part of \
+completions."
   (ignore-errors
     (save-excursion
       (let ((end (progn
@@ -64,19 +65,20 @@
         (buffer-substring-no-properties start end)))))
 
 (defun company-emacs-eclim--candidates (prefix)
-  (let ((before-prefix-in-buffer (company-emacs-eclim--before-prefix-in-buffer prefix)))
+  (let ((before-prefix-in-buffer
+         (company-emacs-eclim--before-prefix-in-buffer prefix)))
     (cl-labels
         ((annotate (str)
-                   (if (string-match "(" str)
-                       (propertize
-                        (substring str 0 (match-beginning 0)) 'eclim-meta str)
-                     str))
+           (if (string-match "(" str)
+               (propertize
+                (substring str 0 (match-beginning 0)) 'eclim-meta str)
+             str))
          (without-redundant-prefix (str)
-                                   (if (and before-prefix-in-buffer
-                                            (> (length before-prefix-in-buffer) 0)
-                                            (string-prefix-p before-prefix-in-buffer str))
-                                       (substring str (length before-prefix-in-buffer))
-                                     str)))
+           (if (and before-prefix-in-buffer
+                    (> (length before-prefix-in-buffer) 0)
+                    (string-prefix-p before-prefix-in-buffer str))
+               (substring str (length before-prefix-in-buffer))
+             str)))
       (mapcar
        (lambda (candidate)
          (annotate (without-redundant-prefix candidate)))
@@ -92,8 +94,10 @@
       (substring str (match-beginning 0)))))
 
 ;;;###autoload
-(defun company-emacs-eclim (command &optional arg &rest ignored)
-  "`company-mode' back-end for Eclim completion"
+(defun company-emacs-eclim (command &optional arg &rest _ignored)
+  "Eclim `company' completion backend.
+
+See `company' for explanation of COMMAND and ARG."
   (interactive (list 'interactive))
   (cl-case command
     (interactive (company-begin-backend 'company-emacs-eclim))

--- a/eclim-ant.el
+++ b/eclim-ant.el
@@ -26,7 +26,7 @@
 ;;
 ;;; Commentary:
 ;;
-;;* Eclim Ant
+;;; Code:
 
 (require 'eclim-common)
 
@@ -36,12 +36,12 @@
 (define-key eclim-mode-map (kbd "C-c C-e a v") 'eclim-ant-validate)
 
 (defgroup eclim-ant nil
-  "Build java projects using Apache Ant"
+  "Build java projects using Apache Ant."
   :group 'eclim)
 
 (defcustom eclim-ant-directory ""
-  "This variable contains the location, where the main buildfile is
-stored. It is used globally for all eclim projects."
+  "This variable contains the location, where the main buildfile is stored.
+It is used globally for all eclim projects."
   :group 'eclim-ant
   :type 'directory)
 
@@ -56,16 +56,19 @@ stored. It is used globally for all eclim projects."
   (concat (file-name-as-directory eclim-ant-directory) eclim-ant-buildfile-name))
 
 (defun eclim--ant-buildfile-path ()
-  (file-name-directory (concat (eclim--project-dir) "/" (eclim--ant-buildfile-name))))
+  (file-name-directory
+   (concat (eclim--project-dir) "/" (eclim--ant-buildfile-name))))
 
 (defun eclim--ant-targets (project buildfile)
   (when (null eclim--ant-target-cache)
     (setq eclim--ant-target-cache (make-hash-table :test 'equal)))
   (or (gethash buildfile eclim--ant-target-cache)
-      (puthash buildfile (eclim/ant-target-list project buildfile) eclim--ant-target-cache)))
+      (puthash buildfile (eclim/ant-target-list project buildfile)
+               eclim--ant-target-cache)))
 
 (defun eclim--ant-read-target (project buildfile)
-  (eclim--completing-read "Target: " (append (eclim--ant-targets project buildfile) nil)))
+  (eclim--completing-read
+   "Target: " (append (eclim--ant-targets project buildfile) nil)))
 
 (defun eclim/ant-validate (project buildfile)
   (eclim--check-project project)
@@ -78,8 +81,9 @@ stored. It is used globally for all eclim projects."
   (eclim--call-process "ant_targets" "-p" project "-f" buildfile))
 
 (defun eclim-ant-clear-cache ()
-  "Clear the cached ant target list. This can be usefull when the
-buildfile for the current project has changed and needs to be updated"
+  "Clear the cached ant target list.
+This can be usefull when the buildfile for the current project has changed and
+needs to be updated."
   (interactive)
   (setq eclim--ant-target-cache nil))
 
@@ -99,9 +103,9 @@ buildfile for the current project has changed and needs to be updated"
 ;;   (compilation-mode))
 
 (defun eclim-ant-run (target)
-  "run a specified ant target in the scope of the current project. If
-the function is called interactively the users is presented with a
-  list of all available ant targets."
+  "Run a specified ant TARGET in the scope of the current project.
+If the function is called interactively the users is presented with a list of
+all available ant targets."
   (interactive (list (eclim--ant-read-target (eclim-project-name)
                                              (eclim--ant-buildfile-name))))
   (let ((default-directory (eclim--ant-buildfile-path)))
@@ -109,3 +113,4 @@ the function is called interactively the users is presented with a
     (compile (concat "ant " target))))
 
 (provide 'eclim-ant)
+;;; eclim-ant.el ends here

--- a/eclim-java-run.el
+++ b/eclim-java-run.el
@@ -1,4 +1,4 @@
-;; eclim-java-run.el --- an interface to the Eclipse IDE.  -*- lexical-binding: t; -*-
+;; eclim-java-run.el --- Eclipse IDE interface. -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (C) 2015 Łukasz Klich
 ;;
@@ -19,7 +19,6 @@
 ;;
 ;;; Contributors
 ;;
-;;
 ;;; Commentary:
 ;;
 ;;; Conventions
@@ -31,6 +30,7 @@
 ;;
 ;; eclim-java-run.el -- java run configurations for eclim
 ;;
+;;; Code:
 
 (require' eclim-project)
 (require 'eclim-java)
@@ -49,15 +49,15 @@
 
 (defun eclim-java-run--project-sourcepath (project)
   (eclim-java-run--read-sourcepath
-   (concat (eclim-java-run--project-dir project)
-           ".classpath")))
+   (concat (eclim-java-run--project-dir project) ".classpath")))
 
 (defun eclim-java-run--read-sourcepath (classpath-file)
   (let* ((root (car (xml-parse-file classpath-file)))
          (classpathentries (xml-get-children root 'classpathentry))
          (srcs (-filter 'eclim-java-run--src?? classpathentries))
          (paths-relative (-map 'eclim-java-run--get-path srcs))
-         (paths-absolute (--map (concat (file-name-directory classpath-file) it) paths-relative)))
+         (paths-absolute (--map (concat (file-name-directory classpath-file) it)
+                                paths-relative)))
     paths-absolute))
 
 (defun eclim-java-run--src?? (classpathentry)
@@ -76,8 +76,10 @@
     (buffer-string)))
 
 (defun eclim-java-run--load-configurations (project)
-  (let* ((configurations-path (concat (eclim-java-run--project-dir project) ".eclim"))
-         (configurations (read (eclim-java-run--get-string-from-file configurations-path))))
+  (let* ((configurations-path
+          (concat (eclim-java-run--project-dir project) ".eclim"))
+         (configurations
+          (read (eclim-java-run--get-string-from-file configurations-path))))
     configurations))
 
 (defun eclim-java-run--get-value (key alist)
@@ -108,21 +110,24 @@
                 (eclim-java-run--get-value 'program-args config)))))
 
 (defun eclim-java-run--run-jdb (config classpath sourcepath project-dir)
-  (let* ((command (eclim-java-run--command config
-                                           (eclim-java-run--debug-vm-args classpath sourcepath))))
+  (let* ((command (eclim-java-run--command
+                   config
+                   (eclim-java-run--debug-vm-args classpath sourcepath))))
     (with-temp-buffer
       (setq default-directory project-dir)
       (eclim-debug/jdb command))))
 
 (defun eclim-java-run--run-java (config classpath project-dir)
   (let* ((name (eclim-java-run--get-value 'name config))
-         (command (eclim-java-run--command config (eclim-java-run--java-vm-args classpath)))
+         (command (eclim-java-run--command
+                   config (eclim-java-run--java-vm-args classpath)))
          (new-buffer-name (concat "*" name "*")))
     (when (buffer-live-p (get-buffer new-buffer-name)) (kill-buffer new-buffer-name))
     (with-temp-buffer
       (setq default-directory project-dir)
-      (switch-to-buffer (process-buffer
-                         (start-process-shell-command name new-buffer-name command))))))
+      (switch-to-buffer
+       (process-buffer
+        (start-process-shell-command name new-buffer-name command))))))
 
 (defun eclim-java-run--configuration (name confs)
   (car
@@ -135,9 +140,12 @@
                    nil t))
 
 (defun eclim-java-run-run (configuration-name)
+  "Run current project using configurations from CONFIGURATION-NAME."
   (interactive (list (eclim-java-run--ask-which-configuration)))
-  (let* ((configurations (eclim-java-run--load-configurations (eclim-project-name)))
-         (configuration (eclim-java-run--configuration configuration-name configurations))
+  (let* ((configurations
+          (eclim-java-run--load-configurations (eclim-project-name)))
+         (configuration
+          (eclim-java-run--configuration configuration-name configurations))
          (project-dir (eclim-java-run--project-dir (eclim-project-name)))
          (classpath (eclim/java-classpath (eclim-project-name)))
          (debug? (eclim-java-run--jdb? configuration)))
@@ -151,15 +159,18 @@
                                 project-dir))))
 
 (defun eclim-run-configuration (configuration-name)
-      "Runs the configuration given in CONFIGURATION-NAME in the compilation buffer."
-      (interactive (list (eclim-java-run--ask-which-configuration)))
-      (let* ((configurations (eclim-java-run--load-configurations (eclim-project-name)))
-             (configuration (eclim-java-run--configuration configuration-name configurations))
-             (project-dir (eclim-java-run--project-dir (eclim-project-name)))
-             (classpath (eclim/java-classpath (eclim-project-name)))
-             (default-directory project-dir)
-             (command (eclim-java-run--command configuration (eclim-java-run--java-vm-args classpath))))
-        (compile command)))
+  "Runs the configuration given in CONFIGURATION-NAME in the compilation buffer."
+  (interactive (list (eclim-java-run--ask-which-configuration)))
+  (let* ((configurations
+          (eclim-java-run--load-configurations (eclim-project-name)))
+         (configuration
+          (eclim-java-run--configuration configuration-name configurations))
+         (project-dir (eclim-java-run--project-dir (eclim-project-name)))
+         (classpath (eclim/java-classpath (eclim-project-name)))
+         (default-directory project-dir)
+         (command (eclim-java-run--command
+                   configuration (eclim-java-run--java-vm-args classpath))))
+    (compile command)))
 
 (provide 'eclim-java-run)
 ;;; eclim-java-run.el ends here

--- a/eclim-macros.el
+++ b/eclim-macros.el
@@ -27,14 +27,17 @@
 ;; Macros used by this package.
 ;;
 ;;; Code:
+(eval-when-compile (require 'cl-lib))
 
 (defun eclim--args-contains (args flags)
   "Validate that ARGS (not expanded) has the specified FLAGS."
   (cl-loop for f in flags
-           return (cl-find f args :test #'string= :key (lambda (a) (if (listp a) (car a) a)))))
+     return (cl-find f args
+                     :test #'string=
+                     :key (lambda (a) (if (listp a) (car a) a)))))
 
 (defun eclim--evaluating-args-form (args)
-  "Return a form which evaluates the elements of the list ARGS.
+  "Returns a form which evaluates the elements of the list ARGS.
 If a list element is of the form (STRING EXPRESSION), only
 EXPRESSION will be evaluated by the form to some RESULT,
 and \(STRING RESULT) will be the element contained in the
@@ -132,10 +135,13 @@ and also bound to PROBLEMS while evaluating BODY."
   (let ((res (cl-gensym)))
     `(when eclim--problems-project
        (setq eclim--problems-refreshing t)
-       (eclim/with-results-async ,res ("problems" ("-p" eclim--problems-project) (when (string= "e" eclim--problems-filter) '("-e" "true")))
+       (eclim/with-results-async ,res
+         ("problems" ("-p" eclim--problems-project)
+          (when (string= "e" eclim--problems-filter)
+            '("-e" "true")))
          (cl-loop for problem across ,res
-                  do (let ((filecell (assq 'filename problem)))
-                       (when filecell (setcdr filecell (file-truename (cdr filecell))))))
+            do (let ((filecell (assq 'filename problem)))
+                 (when filecell (setcdr filecell (file-truename (cdr filecell))))))
          (setq eclim--problems-list ,res)
          (let ((,problems ,res))
            (setq eclim--problems-refreshing nil)
@@ -155,4 +161,4 @@ current buffer is still live when the closure is called."
              ,@body))))))
 
 (provide 'eclim-macros)
-;;;
+;;; eclim-macros.el ends here

--- a/eclim-maven.el
+++ b/eclim-maven.el
@@ -17,7 +17,6 @@
 ;;
 ;;; Contributors
 ;;
-;;
 ;;; Commentary:
 ;;
 ;;; Conventions
@@ -25,8 +24,8 @@
 ;; Conventions used in this file: Name internal variables and functions
 ;; "eclim--<descriptive-name>", and name eclim command invocations
 ;; "eclim/command-name", like eclim/project-list.
-
-;;* Eclim Maven
+;;
+;;; Code:
 
 (require 'compile)
 (require 'eclim-common)
@@ -41,7 +40,8 @@
 (define-key eclim-mode-map (kbd "C-c C-e m r") 'eclim-maven-run)
 
 (defvar eclim-maven-lifecycle-phases
-  '("validate" "compile" "test" "package" "integration" "verify" "install" "deploy"))
+  '("validate" "compile" "test" "package" "integration" "verify" "install" "deploy")
+  "Maven lifecycle phases.")
 
 (defun eclim--maven-lifecycle-phase-read ()
   (completing-read "Phase: " eclim-maven-lifecycle-phases))
@@ -53,18 +53,17 @@
   (let ((default-directory (eclim--project-dir)))
     (compile (concat "mvn -f " (eclim--maven-pom-path) " " command))))
 
-
-
 (defun eclim-maven-run (goal)
-  "Execute a specific Maven goal in the context of the current
-project. The build output is displayed in the *compilation* buffer."
+  "Execute a specific Maven GOAL in the context of the current project.
+The build output is displayed in the *compilation* buffer."
   (interactive "MGoal: ")
   (eclim--maven-execute goal))
 
 (defun eclim-maven-lifecycle-phase-run (phase)
-  "Run any given Maven life-cycle phase in the context of the current
-project. The build output is displayed in the *compilation* buffer."
+  "Run any given Maven life-cycle PHASE in the context of the current project.
+The build output is displayed in the *compilation* buffer."
   (interactive (list (eclim--maven-lifecycle-phase-read)))
   (eclim-maven-run phase))
 
 (provide 'eclim-maven)
+;;; eclim-maven.el ends here

--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -1,4 +1,4 @@
-;;; eclim-problems.el --- an interface to the Eclipse IDE.  -*- lexical-binding: t -*-
+;;; eclim-problems.el --- Eclipse IDE interface -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2009, 2012  Tassilo Horn <tassilo@member.fsf.org>
 ;;
@@ -23,8 +23,6 @@
 ;;  - Alessandro Arzilli <alessandro.arzilli * gmail com>
 ;;
 ;;; Commentary:
-;;
-;;
 ;;; Code:
 
 (require 'popup)
@@ -153,7 +151,9 @@ that only warnings are reported."
   "Highlight problems in a source buffer when switching windows."
   (eclim-problems-highlight))
 
-(defun eclim-problems-advice-switch-to-buffer (_buffer-or-name &optional _norecord _force-same-window)
+(defun eclim-problems-advice-switch-to-buffer (_buffer-or-name
+                                               &optional _norecord
+                                               _force-same-window)
   "Highlight problems in a source buffer when switching buffers."
   (eclim-problems-highlight))
 
@@ -176,8 +176,10 @@ raised if no problem corresponds to the current position."
       (save-restriction
         (widen)
         (let ((line (line-number-at-pos)))
-          (or (cl-find-if (lambda (p) (and (string= (assoc-default 'filename p) (file-truename buffer-file-name))
-                                           (= (assoc-default 'line p) line)))
+          (or (cl-find-if (lambda (p)
+                            (and (string= (assoc-default 'filename p)
+                                          (file-truename buffer-file-name))
+                                 (= (assoc-default 'line p) line)))
                           eclim--problems-list)
               (error "No problem on this line")))))))
 
@@ -201,7 +203,8 @@ source code buffer."
   (interactive)
   (let ((p (eclim--problems-get-current-problem)))
     (unless (string-match "\\.\\(groovy\\|java\\)$" (cdr (assoc 'filename p)))
-      (error "Not a Java or Groovy file.  Corrections are currently supported only for Java or Groovy"))
+      (error "Not a Java or Groovy file.  \
+Corrections are currently supported only for Java or Groovy"))
     (if (eq major-mode 'eclim-problems-mode)
         (let ((p-buffer (find-file-other-window (assoc-default 'filename p))))
           (with-selected-window (get-buffer-window p-buffer t)
@@ -251,7 +254,8 @@ If the problems buffer does not exist yet, it is created."
   (interactive)
   (if (eclim-project-name)
       (eclim--problems-mode-init)
-    (error "Could not figure out the current project. Is this an eclim managed buffer?")))
+    (error "Could not figure out the current project.  \
+Is this an eclim managed buffer?")))
 
 (defun eclim-problems-open ()
   "Switch to the problems buffer in a new Emacs window.
@@ -383,22 +387,27 @@ is currently not respected, however.
 PROJECT-DIRECTORY is the path to the project root directory.
 It will be stripped from file names before they are
 displayed."
-  (let ((filename (cl-first (split-string (assoc-default 'filename problem) project-directory t)))
+  (let ((filename
+         (cl-first (split-string (assoc-default 'filename problem)
+                                 project-directory t)))
         (description (assoc-default 'message problem))
         (type (if (eq t (assoc-default 'warning problem)) "W" "E")))
     (let ((line (assoc-default 'line problem))
           (col (assoc-default 'column problem)))
-      (insert (format "%s:%s:%s: %s: %s\n" filename line col (upcase type) description)))))
+      (insert
+       (format "%s:%s:%s: %s: %s\n" filename line col (upcase type) description)))))
 
 (defun eclim--count-current-errors ()
   "Count the number of problems which are errors."
   (length
-   (eclim--filter-problems "e" t (buffer-file-name (current-buffer)) eclim--problems-list)))
+   (eclim--filter-problems
+    "e" t (buffer-file-name (current-buffer)) eclim--problems-list)))
 
 (defun eclim--count-current-warnings ()
   "Count the number of problems which are warnings."
   (length
-   (eclim--filter-problems "w" t (buffer-file-name (current-buffer)) eclim--problems-list)))
+   (eclim--filter-problems
+    "w" t (buffer-file-name (current-buffer)) eclim--problems-list)))
 
 (defun eclim-problems-next-same-file (&optional up)
   "Move to the next problem in the current file, with wraparound.

--- a/eclim-scala.el
+++ b/eclim-scala.el
@@ -19,7 +19,6 @@
 ;;
 ;; - Shuai Lin <linshuai2012@gmail.com>
 ;;
-;;
 ;;; Commentary:
 ;;
 ;;; Conventions
@@ -27,6 +26,8 @@
 ;; Conventions used in this file: Name internal variables and functions
 ;; "eclim--<descriptive-name>", and name eclim command invocations
 ;; "eclim/command-name", like eclim/project-list.
+;;
+;;; Code:
 
 ;;* Eclim Scala
 
@@ -49,3 +50,4 @@
       (eclim--find-display-results (cdr i) hits t))))
 
 (provide 'eclim-scala)
+;;; eclim-scala.el ends here

--- a/maint/eclim-lint.el
+++ b/maint/eclim-lint.el
@@ -26,6 +26,14 @@
 
 (require 'f)
 
+(eval-when-compile
+  (defvar checkdoc-force-docstrings-flag)
+  (defvar checkdoc-arguments-in-order-flag) ;default changed 26.1
+  (defvar checkdoc-verb-check-experimental-flag)
+  (defvar elisp-lint-ignored-validators))
+(declare-function elisp-lint-files-batch "elisp-lint")
+(declare-function flycheck-package-setup "flycheck-package")
+
 (defvar eclim-test-path
   (f-dirname (f-this-file)))
 
@@ -39,7 +47,8 @@
   "Initialize Emacs with Cask packages an invoke ACTION."
   (let* ((load-prefer-newer t)
          (source-directory (locate-dominating-file eclim-test-path "Cask"))
-         (pkg-rel-dir (format ".cask/%s.%S/elpa" emacs-major-version emacs-minor-version)))
+         (pkg-rel-dir
+          (format ".cask/%s.%S/elpa" emacs-major-version emacs-minor-version)))
 
     (setq package-user-dir (expand-file-name pkg-rel-dir source-directory))
     (package-initialize)
@@ -55,18 +64,22 @@
   (eclim-emacs-init
    (lambda ()
      (setq elisp-lint-ignored-validators '("package-format"
-                                           "fill-column"
+                                           ;; "fill-column"
                                            "byte-compile"
                                            "indent"))
      (add-hook 'emacs-lisp-mode-hook
                (lambda ()
                  (setq indent-tabs-mode nil)
-                 (setq fill-column 80)))
+                 (setq fill-column 85)
+                 (setq checkdoc-force-docstrings-flag nil
+                       checkdoc-arguments-in-order-flag nil ;default changed 26.1
+                       checkdoc-verb-check-experimental-flag nil)))
      (let ((debug-on-error t))
        (elisp-lint-files-batch)))))
 
 (defun eclim-package-lint ()
-  "Checks that the metadata in Emacs Lisp files which to ensure they are intended to be packages."
+  "Checks that the metadata in Emacs Lisp files which to ensure they are
+intended to be packages."
   (eclim-emacs-init
    (lambda ()
      (eval-after-load 'flycheck

--- a/test/company-emacs-eclim-test.el
+++ b/test/company-emacs-eclim-test.el
@@ -22,6 +22,7 @@
 ;;; Code:
 
 (require 'company-emacs-eclim)
+(eval-when-compile (require 'cl))
 (require 'noflet)
 
 (ert-deftest compute-full-prefix-when-complete-import ()

--- a/test/eclim-common-test.el
+++ b/test/eclim-common-test.el
@@ -22,7 +22,6 @@
 ;;; Code:
 
 (require 'eclim-common "eclim-common.el")
-(require 'cl)
 
 (ert-deftest java-accepted-filename-p-test ()
   (should (equal (eclim--accepted-filename-p "test.java") t)))

--- a/test/parser-test.el
+++ b/test/parser-test.el
@@ -21,7 +21,7 @@
 
 ;;; Code:
 
-(ert-deftest java-parser-read-complex-signarure()
+(ert-deftest java-parser-read-complex-signarure ()
   (should (equal (eclim--java-parser-read "public Message<?> preSend(org.springframework.integration.Message<?>,org.springframework.integration.MessageChannel)")
                  '(public Message ((\?)) preSend ((org\.springframework\.integration\.Message ((\?))) (org\.springframework\.integration\.MessageChannel))))))
 

--- a/test/specs/test-eclim-common.el
+++ b/test/specs/test-eclim-common.el
@@ -101,7 +101,7 @@
                     (it "should throw an error for a bad support"
                         (let ((support-types
                                '(xml_complete groovy_complete ruby_complete c_complete php_complete scala_complete)))
-                          (loop
+                          (cl-loop
                            for support-type in support-types
                            do (expect (eclim--parse-result (format "No command '%s' found" support-type))
                                       :to-throw 'error))))


### PR DESCRIPTION
This just adds documentation to interactive functions
and formats code to make the linter happy. It also replaces
cl dependencies with cl-lib.