### PR TITLE
add customizable prefix key

### DIFF
--- a/eclim-ant.el
+++ b/eclim-ant.el
@@ -27,17 +27,18 @@
 ;;; Commentary:
 ;;
 ;;; Code:
-
+(eval-when-compile (require 'eclim-macros))
 (require 'eclim-common)
-
-(define-key eclim-mode-map (kbd "C-c C-e a c") 'eclim-ant-clear-cache)
-(define-key eclim-mode-map (kbd "C-c C-e a r") 'eclim-ant-run)
-(define-key eclim-mode-map (kbd "C-c C-e a a") 'eclim-ant-run)
-(define-key eclim-mode-map (kbd "C-c C-e a v") 'eclim-ant-validate)
 
 (defgroup eclim-ant nil
   "Build java projects using Apache Ant."
   :group 'eclim)
+
+(eclim-bind-keys (:map eclim-ant-keymap :prefix "a" :doc "Eclim Ant")
+  ("c" . eclim-ant-clear-cache)
+  ("r" . eclim-ant-run)
+  ("a" . eclim-ant-run)
+  ("v" . eclim-ant-validate))
 
 (defcustom eclim-ant-directory ""
   "This variable contains the location, where the main buildfile is stored.

--- a/eclim-common.el
+++ b/eclim-common.el
@@ -28,13 +28,13 @@
 ;;
 ;;; Code:
 
-(eval-when-compile (require 'cl-lib))
+(eval-when-compile
+  (require 'cl-lib)
+  (require 'dash))
 (require 'etags)
 (require 'json)
 (require 'arc-mode)
 (require 'popup)
-(require 'dash)
-;;(eval-when-compile (require 'eclim-macros))
 (require 'eclim-macros)
 
 (declare-function eclim--get-problems-buffer-create "eclim-problems")
@@ -45,6 +45,21 @@
     (define-key map (kbd "M-TAB") 'eclim-complete)
     map)
   "The keymap used in command `eclim-mode'.")
+
+(defcustom eclim-keymap-prefix "C-c C-e"
+  "Eclim keymap prefix."
+  :type 'string
+  :group 'eclim
+  :set (lambda (var key)
+         (when (and (boundp var) (symbol-value var))
+           (define-key eclim-mode-map (read-kbd-macro (symbol-value var))
+             'eclim-command-map))
+         (when key
+           (define-key eclim-mode-map (read-kbd-macro key) 'eclim-command-map))
+         (set var key)))
+
+(define-prefix-command 'eclim-command-map nil "Eclim command map")
+(define-key eclim-mode-map (kbd eclim-keymap-prefix) 'eclim-command-map)
 
 (defvar eclimd-process nil
   "The active eclimd process.")

--- a/eclim-completion.el
+++ b/eclim-completion.el
@@ -34,7 +34,7 @@
 ;;; Code:
 
 (require 'thingatpt)
-(require 'cl-lib)
+(eval-when-compile (require 'cl-lib))
 (require 's)
 (require 'yasnippet)
 (require 'eclim-common)

--- a/eclim-debug.el
+++ b/eclim-debug.el
@@ -32,19 +32,19 @@
 ;; support debugging
 ;;
 ;;; Code:
-
+(eval-when-compile (require 'eclim-macros))
+(require 'eclim-common)
 (require 'eclim-project)
 (require 'eclim-java)
 (require 'eclim-maven)
 (require 'eclim-ant)
 (require 'eclim-java-run)
-(require 'eclim-common)
 (require 'gud)
-(require 'dash)
 (require 's)
 
-(define-key eclim-mode-map (kbd "C-c C-e p t") 'eclim-debug-test)
-(define-key eclim-mode-map (kbd "C-c C-e p a") 'eclim-debug-attach)
+(eclim-bind-keys (:map eclim-debug-keymap :prefix "p" :doc "Eclim Debug")
+  ("t" . eclim-debug-test)
+  ("a" . eclim-debug-attach))
 
 (defun eclim--debug-jdb-run-command (project main-class args)
   (let ((config `((name . ,(concat "*Debug - " main-class "*"))

--- a/eclim-java-run.el
+++ b/eclim-java-run.el
@@ -32,13 +32,16 @@
 ;;
 ;;; Code:
 
+(eval-when-compile 'eclim-macros)
+(require 'eclim-common)
 (require' eclim-project)
 (require 'eclim-java)
 (require 's)
 (require 'dash)
 (require 'xml)
 
-(define-key eclim-mode-map (kbd "C-c C-e u r") 'eclim-java-run-run)
+(eclim-bind-keys (:map java-run-keymap :prefix "u" :doc "Eclim Java Run")
+  ("r" . eclim-java-run-run))
 
 (defun eclim-java-run-sourcepath (project)
   (let ((projects (-snoc (eclim-project-dependencies project) project)))

--- a/eclim-java.el
+++ b/eclim-java.el
@@ -28,35 +28,31 @@
 ;; "eclim/command-name", like eclim/project-list.
 ;;
 ;;; Code:
-
-;;* Eclim Java
-
 (require 'json)
-(require 'dash)
-(require 'cl-lib)
 (require 'format-spec)
 (require 'eclim-common)
 (require 'eclim-problems)
-(eval-when-compile (require 'eclim-macros))
+(eval-when-compile
+  (require 'eclim-macros)
+  (require 'cl-lib)
+  (require 'dash))
 
-(define-key eclim-mode-map (kbd "C-c C-e d")   'eclim-java-doc-comment)
-(define-key eclim-mode-map (kbd "C-c C-e f d") 'eclim-java-find-declaration)
-(define-key eclim-mode-map (kbd "C-c C-e f f") 'eclim-java-find-generic)
-(define-key eclim-mode-map (kbd "C-c C-e f r") 'eclim-java-find-references)
-(define-key eclim-mode-map (kbd "C-c C-e f s") 'eclim-java-format)
-(define-key eclim-mode-map (kbd "C-c C-e f t") 'eclim-java-find-type)
-(define-key eclim-mode-map (kbd "C-c C-e g")
-  'eclim-java-generate-getter-and-setter)
-(define-key eclim-mode-map (kbd "C-c C-e h")   'eclim-java-hierarchy)
-(define-key eclim-mode-map (kbd "C-c C-e i")   'eclim-java-import-organize)
-(define-key eclim-mode-map (kbd "C-c C-e n")   'eclim-java-new)
-(define-key eclim-mode-map (kbd "C-c C-e r")
-  'eclim-java-refactor-rename-symbol-at-point)
-;; this function doesn't exist
-;; (define-key eclim-mode-map (kbd "C-c C-e s")
-;; 'eclim-java-method-signature-at-point)
-(define-key eclim-mode-map (kbd "C-c C-e t")   'eclim-run-junit)
-(define-key eclim-mode-map (kbd "C-c C-e z")   'eclim-java-implement)
+(eclim-bind-keys (:map eclim-command-map)
+  ("d"   . eclim-java-doc-comment)
+  ("f d" . eclim-java-find-declaration)
+  ("f f" . eclim-java-find-generic)
+  ("f r" . eclim-java-find-references)
+  ("f s" . eclim-java-format)
+  ("f t" . eclim-java-find-type)
+  ("g"   . eclim-java-generate-getter-and-setter)
+  ("h"   . eclim-java-hierarchy)
+  ("i"   . eclim-java-import-organize)
+  ("n"   . eclim-java-new)
+  ("r"   . eclim-java-refactor-rename-symbol-at-point)
+  ;; this is not defined
+  ;; ("s"   . eclim-java-method-signature-at-point)
+  ("t"   . eclim-run-junit)
+  ("z"   . eclim-java-implement))
 
 (defvar eclim-java-show-documentation-map
   (let ((map (make-keymap)))

--- a/eclim-macros.el
+++ b/eclim-macros.el
@@ -160,5 +160,20 @@ current buffer is still live when the closure is called."
            (with-current-buffer ,caller-current-buffer-symbol
              ,@body))))))
 
+(cl-defmacro eclim-bind-keys ((&key (map) (prefix) (doc)) &rest bindings)
+  "Bind BINDINGS to leader MAP with PREFIX in variable `eclim-command-map'.
+If MAP or PREFIX are nil, then bind in variable `eclim-command-map'."
+  (declare (indent defun))
+  `(progn
+     ,@(if (and map prefix)
+           `((progn
+               (defvar ,map)
+               (define-prefix-command ',map nil ,doc)
+               (define-key eclim-command-map (kbd ,prefix) ',map)
+               ,@(cl-loop for (k . b) in bindings
+                    collect `(define-key ,map (kbd ,k) ',b))))
+         (cl-loop for (k . b) in bindings
+            collect `(define-key eclim-command-map (kbd ,k) ',b)))))
+
 (provide 'eclim-macros)
 ;;; eclim-macros.el ends here

--- a/eclim-maven.el
+++ b/eclim-maven.el
@@ -27,17 +27,19 @@
 ;;
 ;;; Code:
 
+(eval-when-compile (require 'eclim-macros))
 (require 'compile)
 (require 'eclim-common)
+
+(eclim-bind-keys (:map eclim-maven-keymap :prefix "m" :doc "Eclim Maven")
+  ("p" . eclim-maven-lifecycle-phase-run)
+  ("r" . eclim-maven-run))
 
 ;; Add regexp to make compilation-mode understand maven2 errors
 (setq compilation-error-regexp-alist
       (append (list
                '("\\[ERROR]\\ \\(\/.*\\):\\[\\([0-9]*\\),\\([0-9]*\\)]" 1 2 3))
               compilation-error-regexp-alist))
-
-(define-key eclim-mode-map (kbd "C-c C-e m p") 'eclim-maven-lifecycle-phase-run)
-(define-key eclim-mode-map (kbd "C-c C-e m r") 'eclim-maven-run)
 
 (defvar eclim-maven-lifecycle-phases
   '("validate" "compile" "test" "package" "integration" "verify" "install" "deploy")

--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -27,9 +27,10 @@
 
 (require 'popup)
 (require 'hl-line)
-(require 'cl-lib)
 (require 'eclim-common)
-(eval-when-compile (require 'eclim-macros))
+(eval-when-compile
+  (require 'eclim-macros)
+  (require 'cl-lib))
 
 (defgroup eclim-problems nil
   "Settings for displaying problems in code and the problems buffer."
@@ -62,8 +63,9 @@
         map)
   "The local key map to use in `eclim-problems-mode'.")
 
-(define-key eclim-mode-map (kbd "C-c C-e b") 'eclim-problems)
-(define-key eclim-mode-map (kbd "C-c C-e o") 'eclim-problems-open)
+(eclim-bind-keys (:map eclim-command-map)
+  ("b" . eclim-problems)
+  ("o" . eclim-problems-open))
 
 (defconst eclim--problems-buffer-name "*eclim: problems*"
   "The name to use for the problems buffer.")

--- a/eclim-project.el
+++ b/eclim-project.el
@@ -63,14 +63,17 @@
 (defvar eclim-project-info-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map special-mode-map)
-        map))
+    map))
 
-(define-key eclim-mode-map (kbd "C-c C-e g") 'eclim-project-goto)
-(define-key eclim-mode-map (kbd "C-c C-e p p") 'eclim-project-mode)
-(define-key eclim-mode-map (kbd "C-c C-e p m") 'eclim-project-mode)
-(define-key eclim-mode-map (kbd "C-c C-e p i") 'eclim-project-import)
-(define-key eclim-mode-map (kbd "C-c C-e p c") 'eclim-project-create)
-(define-key eclim-mode-map (kbd "C-c C-e p g") 'eclim-project-goto)
+(eclim-bind-keys (:map eclim-command-map)
+  ("g" . eclim-project-goto))
+
+(eclim-bind-keys (:map eclim-project-keymap :prefix "p" :doc "Eclim Project")
+  ("p" . eclim-project-goto)
+  ("m" . eclim-project-mode)
+  ("i" . eclim-project-import)
+  ("c" . eclim-project-create)
+  ("g" . eclim-project-goto))
 
 ;; Clear project caches.
 (defun eclim--project-clear-cache ()

--- a/eclim.el
+++ b/eclim.el
@@ -39,13 +39,11 @@
 
 (require 's)
 (require 'json)
-(require 'eclimd)
 (require 'eclim-common)
 (eval-when-compile
   (require 'eclim-macros)
   (require 'cl-lib))
-
-;;** Basics
+(require 'eclimd)
 
 (defgroup eclim nil
   "Interface to the Eclipse IDE."

--- a/eclimd.el
+++ b/eclimd.el
@@ -31,10 +31,10 @@
 ;;; Code:
 
 (require 'eclim-common)
-;; (require 'dash)
 (eval-when-compile
   (require 'eclim-macros)
-  (require 'cl-lib))
+  (require 'cl-lib)
+  (require 'dash))
 
 ;;;###autoload(defalias 'start-eclimd 'eclimd-start)
 (defalias 'stop-eclimd 'eclimd-stop)


### PR DESCRIPTION
Allows prefix key "C-c C-e" to set using customize-variable and 
defines leader keymaps for the various other modes. 