### PR TITLE
Run Maven in Batch mode

### DIFF
--- a/doc/History.txt
+++ b/doc/History.txt
@@ -3,6 +3,10 @@
 === New features
  * Added support for python
 
+=== Bugfixes
+ * Run Maven in batch mode to avoid colour escape sequences from being
+   displayed.
+
 == 0.5
 
 === New features

--- a/eclim-maven.el
+++ b/eclim-maven.el
@@ -53,7 +53,7 @@
 
 (defun eclim--maven-execute (command)
   (let ((default-directory (eclim--project-dir)))
-    (compile (concat "mvn -f " (eclim--maven-pom-path) " " command))))
+    (compile (concat "mvn -B -f " (eclim--maven-pom-path) " " command))))
 
 (defun eclim-maven-run (goal)
   "Execute a specific Maven GOAL in the context of the current project.

--- a/test/maven-test.el
+++ b/test/maven-test.el
@@ -31,5 +31,11 @@
     (should (string-equal line "22"))
     (should (string-equal column "12"))))
 
+(ert-deftest maven-command-runs-in-batch-mode ()
+  (cl-letf (((symbol-function 'eclim--project-dir) (lambda (&optional project-name) "foo"))
+         ((symbol-function 'compile) (lambda (command) command)))
+    (let ((output (eclim--maven-execute "package")))
+      (should (string-equal output "mvn -B -f foo/pom.xml  package")))))
+
 (provide 'maven-tests)
 ;;; maven-tests.el ends here


### PR DESCRIPTION
This prevents the colour escape sequences from being displayed in the compilation buffer when
Maven 3.5.0+ is used.